### PR TITLE
Support circle obstacles and path display

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ git lfs install
 git lfs pull
 ```
 
-The simulation depends on a specific version of `mcu-firmware` which also depends on a specific version of `RIOT`. So to avoid struggle in finding the correct versions of the dependencies, we use git submodules to fix the versions of `mcu-firmware` and `RIOT`. 
+The simulation depends on a specific version of `mcu-firmware` which also depends on a specific version of `RIOT`. So to avoid struggle in finding the correct versions of the dependencies, we use git submodules to fix the versions of `mcu-firmware` and `RIOT`.
 Do not forget to fetch the submodules after `git clone`:
 ```bash
 git submodule update --init
@@ -22,7 +22,7 @@ pip install -e .
 Use the following command to build the native version of the firmware:
 
 ```bash
-make -C submodules/mcu-firmware/applications/cogip2019-cortex BOARD=cogip2019-cortex-native MCUFIRMWARE_OPTIONS=calibration
+make -C submodules/mcu-firmware/applications/cup2019 BOARD=cogip-native
 ```
 
 The variable `QUIET=0` can be added to display compilation commands.

--- a/cogip/entities/asset.py
+++ b/cogip/entities/asset.py
@@ -121,7 +121,7 @@ class AssetEntity(Qt3DCore.QEntity):
         self.ready.emit()
 
     @qtSlot(RobotState)
-    def set_position(self, new_state: RobotState) -> None:
+    def new_robot_state(self, new_state: RobotState) -> None:
         """
         Qt slot called to set the entity's new position.
 

--- a/cogip/entities/dynobstacle.py
+++ b/cogip/entities/dynobstacle.py
@@ -3,9 +3,9 @@ from PySide2.Qt3DCore import Qt3DCore
 from PySide2.Qt3DExtras import Qt3DExtras
 
 
-class DynObstacleEntity(Qt3DCore.QEntity):
+class DynRectObstacleEntity(Qt3DCore.QEntity):
     """
-    A dynamic obstacle detected by the robot.
+    A dynamic rectangle obstacle detected by the robot.
 
     Represented as a transparent red cube.
     """
@@ -14,7 +14,7 @@ class DynObstacleEntity(Qt3DCore.QEntity):
         """
         Class constructor.
         """
-        super(DynObstacleEntity, self).__init__()
+        super().__init__()
 
         self.mesh = Qt3DExtras.QCuboidMesh()
         self.mesh.setZExtent(600)
@@ -53,3 +53,46 @@ class DynObstacleEntity(Qt3DCore.QEntity):
         """
         self.mesh.setXExtent(width)
         self.mesh.setYExtent(length)
+
+
+class DynCircleObstacleEntity(Qt3DCore.QEntity):
+    """
+    A dynamic circle obstacle detected by the robot.
+
+    Represented as a transparent red cylinder.
+    """
+
+    def __init__(self):
+        """
+        Class constructor.
+        """
+        super().__init__()
+
+        self.mesh = Qt3DExtras.QCylinderMesh()
+        self.mesh.setLength(600)
+        self.mesh.setRadius(400)
+        self.addComponent(self.mesh)
+
+        self.material = Qt3DExtras.QDiffuseSpecularMaterial(self)
+        self.material.setDiffuse(QtGui.QColor.fromRgb(255, 0, 0, 100))
+        self.material.setDiffuse(QtGui.QColor.fromRgb(255, 0, 0, 100))
+        self.material.setSpecular(QtGui.QColor.fromRgb(255, 0, 0, 100))
+        self.material.setShininess(1.0)
+        self.material.setAlphaBlendingEnabled(True)
+        self.addComponent(self.material)
+
+        self.transform = Qt3DCore.QTransform(self)
+        self.transform.setRotationX(90)
+        self.addComponent(self.transform)
+
+    def set_position(self, x: int, y: int, radius: int) -> None:
+        """
+        Set the position and size of the dynamic obstacle.
+
+        Arguments:
+            x: Center X position
+            y: Center Y position
+            radius: Obstacle radius
+        """
+        self.transform.setTranslation(QtGui.QVector3D(x, y, self.mesh.length()/2))
+        self.mesh.setRadius(radius)

--- a/cogip/entities/line.py
+++ b/cogip/entities/line.py
@@ -1,0 +1,81 @@
+from array import array
+from typing import Optional
+
+from PySide2 import QtCore, QtGui
+from PySide2.Qt3DCore import Qt3DCore
+from PySide2.Qt3DRender import Qt3DRender
+from PySide2.Qt3DExtras import Qt3DExtras
+
+from cogip.models import models
+
+
+class LineEntity(Qt3DCore.QEntity):
+    """
+    A simple entity drawing a line between two vertices.
+    """
+
+    def __init__(self, color: QtGui.QColor = QtCore.Qt.blue, parent: Optional[Qt3DCore.QEntity] = None):
+        """
+        Class constructor.
+
+        Arguments:
+            color: color
+            parent: parent entity
+        """
+        super().__init__(parent)
+        self.color = color
+
+        self.geometry = Qt3DRender.QGeometry(self)
+
+        self.position_buffer = Qt3DRender.QBuffer(self.geometry)
+        self.position_buffer.setType(Qt3DRender.QBuffer.VertexBuffer)
+
+        self.position_attribute = Qt3DRender.QAttribute(self.geometry)
+        self.position_attribute.setName(Qt3DRender.QAttribute.defaultPositionAttributeName())
+        self.position_attribute.setAttributeType(Qt3DRender.QAttribute.VertexAttribute)
+        self.position_attribute.setDataType(Qt3DRender.QAttribute.Float)
+        self.position_attribute.setDataSize(3)
+        self.position_attribute.setCount(2)
+        self.position_attribute.setBuffer(self.position_buffer)
+        self.geometry.addAttribute(self.position_attribute)
+
+        # Connectivity between vertices
+        self.indices = array('I', [0, 1])
+        self.indices_bytes = QtCore.QByteArray(self.indices.tobytes())
+        self.indices_buffer = Qt3DRender.QBuffer(self.geometry)
+        self.indices_buffer.setType(Qt3DRender.QBuffer.VertexBuffer)
+        self.indices_buffer.setData(self.indices_bytes)
+
+        self.indices_attribute = Qt3DRender.QAttribute(self.geometry)
+        self.indices_attribute.setVertexBaseType(Qt3DRender.QAttribute.UnsignedInt)
+        self.indices_attribute.setAttributeType(Qt3DRender.QAttribute.IndexAttribute)
+        self.indices_attribute.setBuffer(self.indices_buffer)
+        self.indices_attribute.setCount(2)
+        self.geometry.addAttribute(self.indices_attribute)
+
+        # Mesh
+        self.line = Qt3DRender.QGeometryRenderer(self)
+        self.line.setGeometry(self.geometry)
+        self.line.setPrimitiveType(Qt3DRender.QGeometryRenderer.Lines)
+        self.material = Qt3DExtras.QPhongMaterial(self)
+        self.material.setAmbient(self.color)
+
+        # Entity
+        self.addComponent(self.line)
+        self.addComponent(self.material)
+
+    def set_points(self, start: models.Vertex, end: models.Vertex):
+        """
+        Set start and end vertices.
+
+        Arguments:
+            start: start position
+            end: end position
+        """
+
+        # Position vertices (start and end)
+        positions = array('f')
+        positions.fromlist([start.x, start.y, start.z])
+        positions.fromlist([end.x, end.y, end.z])
+        buffer_bytes = QtCore.QByteArray(positions.tobytes())
+        self.position_buffer.setData(buffer_bytes)

--- a/cogip/entities/path.py
+++ b/cogip/entities/path.py
@@ -1,0 +1,55 @@
+from typing import List, Optional
+
+from PySide2 import QtCore, QtGui
+from PySide2.Qt3DCore import Qt3DCore
+
+from cogip.entities.line import LineEntity
+from cogip.models import models
+
+
+class PathEntity(Qt3DCore.QEntity):
+    """
+    A simple entity drawing a path along a list of vertices.
+    """
+
+    def __init__(self, color: QtGui.QColor = QtCore.Qt.blue, parent: Optional[Qt3DCore.QEntity] = None):
+        """
+        Class constructor.
+
+        Arguments:
+            color: color
+            parent: parent entity
+        """
+        super().__init__(parent)
+        self.points = []
+        self.color = color
+        self.lines: List[LineEntity] = []
+        self.lines_pool: List[LineEntity] = []
+
+    def set_points(self, points: List[models.Vertex]):
+        """
+        Set points of the path.
+
+        Arguments:
+            points: list of vertices composing the line
+        """
+        self.points = points
+
+        if len(self.points) < 2:
+            return
+
+        for line in self.lines:
+            line.setEnabled(False)
+            self.lines_pool.append(line)
+
+        self.lines = []
+
+        start = self.points.pop(0)
+        for next in self.points:
+            if len(self.lines_pool) == 0:
+                self.lines_pool.append(LineEntity(self.color, self))
+            line = self.lines_pool.pop()
+            line.setEnabled(True)
+            line.set_points(start, next)
+            self.lines.append(line)
+            start = next

--- a/cogip/entities/robot.py
+++ b/cogip/entities/robot.py
@@ -218,7 +218,7 @@ class RobotEntity(AssetEntity):
         self.round_obstacles_pool = current_round_obstacles
 
     @qtSlot(RobotState)
-    def set_position(self, new_state: RobotState) -> None:
+    def new_robot_state(self, new_state: RobotState) -> None:
         """
         Qt slot called to set the robot's new position.
 
@@ -231,4 +231,4 @@ class RobotEntity(AssetEntity):
         state = new_state.copy()
         if not self.enable_tof_sensors and not self.enable_lidar_sensors:
             state.pose_current = new_state.pose_order
-        super(RobotEntity, self).set_position(state)
+        super(RobotEntity, self).new_robot_state(state)

--- a/cogip/entities/robot.py
+++ b/cogip/entities/robot.py
@@ -167,29 +167,17 @@ class RobotEntity(AssetEntity):
 
         for dyn_obstacle in dyn_obstacles.__root__:
             if isinstance(dyn_obstacle, DynObstacleRect):
-                # Rectangle obstacle
-                if len(dyn_obstacle.points) != 4:
-                    continue
-                p0, p1, p2, p3 = dyn_obstacle.points
-                # Compute obstacle size
-                length = math.dist((p0.x, p0.y), (p1.x, p1.y))
-                width = math.dist((p1.x, p1.y), (p2.x, p2.y))
-                # Compute the obstacle center position
-                pos_x = (p0.x + p2.x) / 2
-                pos_y = (p0.y + p2.y) / 2
-                rotation = math.degrees(dyn_obstacle.angle)
-
                 if len(self.rect_obstacles_pool):
-                    dyn_obstacle = self.rect_obstacles_pool.pop(0)
-                    dyn_obstacle.setEnabled(True)
+                    obstacle = self.rect_obstacles_pool.pop(0)
+                    obstacle.setEnabled(True)
                 else:
-                    dyn_obstacle = DynRectObstacleEntity()
-                    dyn_obstacle.setParent(self.parentEntity())
+                    obstacle = DynRectObstacleEntity()
+                    obstacle.setParent(self.parentEntity())
 
-                dyn_obstacle.set_position(x=pos_x, y=pos_y, rotation=rotation)
-                dyn_obstacle.set_size(length=length, width=width)
+                obstacle.set_position(x=dyn_obstacle.x, y=dyn_obstacle.y, rotation=dyn_obstacle.angle)
+                obstacle.set_size(length=dyn_obstacle.length_y, width=dyn_obstacle.length_x)
 
-                current_rect_obstacles.append(dyn_obstacle)
+                current_rect_obstacles.append(obstacle)
             else:
                 # Round obstacle
                 if len(self.round_obstacles_pool):

--- a/cogip/entities/robot.py
+++ b/cogip/entities/robot.py
@@ -220,3 +220,6 @@ class RobotEntity(AssetEntity):
         if not self.enable_tof_sensors and not self.enable_lidar_sensors:
             state.pose_current = new_state.pose_order
         super(RobotEntity, self).new_robot_state(state)
+
+        if state.obstacles:
+            self.set_dyn_obstacles(state.obstacles)

--- a/cogip/models/models.py
+++ b/cogip/models/models.py
@@ -148,11 +148,17 @@ class DynObstacleRect(BaseModel):
     A dynamic rectangle obstacle created by the robot.
 
     Attributes:
-        points: List of the points composing the dynamic obstable
+        x: X coordinate of the obstacle center
+        y: Y coordinate of the obstacle center
         angle: Orientation of the obstacle
+        length_x: length along X axis
+        length_y: length along Y axis
     """
-    points: List[Vertex]
+    x: float
+    y: float
     angle: float
+    length_x: float
+    length_y: float
 
     def __hash__(self):
         """

--- a/cogip/models/models.py
+++ b/cogip/models/models.py
@@ -8,7 +8,7 @@ an exception being raised if impossible.
 """
 
 from enum import IntEnum
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from pydantic import BaseModel
 
@@ -139,9 +139,9 @@ class RobotState(BaseModel):
     speed_order: Optional[Speed] = None
 
 
-class DynObstacle(BaseModel):
+class DynObstacleRect(BaseModel):
     """
-    A dynamic obstacle created by the robot.
+    A dynamic rectangle obstacle created by the robot.
 
     Attributes:
         points: List of the points composing the dynamic obstable
@@ -155,6 +155,29 @@ class DynObstacle(BaseModel):
         Hash function to allow this class to be used as a key in a dict.
         """
         return hash((type(self),) + tuple(self.__root__))
+
+
+class DynRoundObstacle(BaseModel):
+    """
+    A dynamic round obstacle created by the robot.
+
+    Attributes:
+        x: Center X position
+        y: Center Y position
+        radius: Radius of the obstacle
+    """
+    x: float
+    y: float
+    radius: float
+
+    def __hash__(self):
+        """
+        Hash function to allow this class to be used as a key in a dict.
+        """
+        return hash((type(self),) + tuple(self.__root__))
+
+
+DynObstacle = Union[DynRoundObstacle, DynObstacleRect]
 
 
 class DynObstacleList(BaseModel):

--- a/cogip/models/models.py
+++ b/cogip/models/models.py
@@ -80,14 +80,16 @@ class CtrlModeEnum(IntEnum):
 
 class Vertex(BaseModel):
     """
-    Represents a point in 2D coordinates.
+    Represents a point in 2D/3D coordinates.
 
     Attributes:
         x: X position
-        y: Y postion
+        y: Y position
+        z: Z position (optional)
     """
     x: float
     y: float
+    z: float = 0.0
 
     def __hash__(self):
         return hash((type(self),) + tuple(self.__dict__.values()))

--- a/cogip/models/models.py
+++ b/cogip/models/models.py
@@ -132,6 +132,7 @@ class RobotState(BaseModel):
         cycle: Current cycle
         speed_current: Current speed
         speed_order: Speed order
+        path: Computed path
     """
     mode: CtrlModeEnum
     pose_current: Pose
@@ -139,6 +140,7 @@ class RobotState(BaseModel):
     cycle: Optional[int] = None
     speed_current: Optional[Speed] = None
     speed_order: Optional[Speed] = None
+    path: List[Vertex] = []
 
 
 class DynObstacleRect(BaseModel):

--- a/cogip/models/models.py
+++ b/cogip/models/models.py
@@ -119,30 +119,6 @@ class Speed(BaseModel):
     angle: float
 
 
-class RobotState(BaseModel):
-    """
-    This contains information about robot state,
-    like mode, cycle, positions and speed.
-    It is given by the firmware through the serial port.
-
-    Attributes:
-        mode: Current robot mode
-        pose_current: Current robot position
-        pose_order: Position to reach
-        cycle: Current cycle
-        speed_current: Current speed
-        speed_order: Speed order
-        path: Computed path
-    """
-    mode: CtrlModeEnum
-    pose_current: Pose
-    pose_order: Pose
-    cycle: Optional[int] = None
-    speed_current: Optional[Speed] = None
-    speed_order: Optional[Speed] = None
-    path: List[Vertex] = []
-
-
 class DynObstacleRect(BaseModel):
     """
     A dynamic rectangle obstacle created by the robot.
@@ -204,6 +180,31 @@ class DynObstacleList(BaseModel):
         Hash function to allow this class to be used as a key in a dict.
         """
         return hash((type(self),) + tuple(self.__root__))
+
+
+class RobotState(BaseModel):
+    """
+    This contains information about robot state,
+    like mode, cycle, positions, speed, path and obstacles.
+    It is given by the firmware through the serial port.
+
+    Attributes:
+        mode: Current robot mode
+        pose_current: Current robot position
+        pose_order: Position to reach
+        cycle: Current cycle
+        speed_current: Current speed
+        speed_order: Speed order
+        path: Computed path
+    """
+    mode: CtrlModeEnum
+    pose_current: Pose
+    pose_order: Pose
+    cycle: Optional[int] = None
+    speed_current: Optional[Speed] = None
+    speed_order: Optional[Speed] = None
+    path: List[Vertex] = []
+    obstacles: DynObstacleList
 
 
 class Obstacle(BaseModel):

--- a/cogip/tools/simulator/__main__.py
+++ b/cogip/tools/simulator/__main__.py
@@ -157,8 +157,8 @@ def main():
     win.signal_save_obstacles.connect(win.game_view.save_obstacles)
 
     # Connect Controller signals to Robot slots
-    controller.signal_new_robot_state.connect(robot_entity.set_position)
-    controller.signal_new_robot_state.connect(robot_final_entity.set_position)
+    controller.signal_new_robot_state.connect(robot_entity.new_robot_state)
+    controller.signal_new_robot_state.connect(robot_final_entity.new_robot_state)
     controller.signal_new_dyn_obstacles.connect(robot_entity.set_dyn_obstacles)
 
     # Connect Controller signals to UI slots

--- a/cogip/tools/simulator/__main__.py
+++ b/cogip/tools/simulator/__main__.py
@@ -35,6 +35,11 @@ def get_argument_parser(default_uart: str = "/tmp/ptsCOGIP"):
         dest="native_binary", default=settings.native_binary, type=Path,
         help="Specify native board binary compiled in calibration mode"
     )
+    arg_parser.add_argument(
+        "-n", "--no-wait",
+        dest="no_wait", action='store_true',
+        help="Don't wait for the firmware start sequence"
+    )
     return arg_parser
 
 
@@ -94,7 +99,7 @@ def main():
         socat_process = subprocess.Popen(socat_args, executable=socat_path)
 
     # Create controller
-    controller = SerialController(args.uart_device)
+    controller = SerialController(args.uart_device, no_wait=args.no_wait)
 
     # Create QApplication
     app = QtWidgets.QApplication(sys.argv)

--- a/cogip/tools/simulator/__main__.py
+++ b/cogip/tools/simulator/__main__.py
@@ -159,6 +159,7 @@ def main():
     # Connect Controller signals to Robot slots
     controller.signal_new_robot_state.connect(robot_entity.new_robot_state)
     controller.signal_new_robot_state.connect(robot_final_entity.new_robot_state)
+    controller.signal_new_robot_state.connect(win.game_view.new_robot_state)
     controller.signal_new_dyn_obstacles.connect(robot_entity.set_dyn_obstacles)
 
     # Connect Controller signals to UI slots

--- a/cogip/tools/simulator/__main__.py
+++ b/cogip/tools/simulator/__main__.py
@@ -33,7 +33,7 @@ def get_argument_parser(default_uart: str = "/tmp/ptsCOGIP"):
     iodevice_group.add_argument(
         "-B", "--binary",
         dest="native_binary", default=settings.native_binary, type=Path,
-        help="Specify native board binary compiled in calibration mode"
+        help="Specify native binary compiled with shell menus enabled"
     )
     iodevice_group.add_argument(
         "-r", "--remote",
@@ -43,7 +43,7 @@ def get_argument_parser(default_uart: str = "/tmp/ptsCOGIP"):
     arg_parser.add_argument(
         "-n", "--no-wait",
         dest="no_wait", action='store_true',
-        help="Don't wait for the firmware start sequence"
+        help="Do not wait for the firmware start sequence"
     )
     return arg_parser
 

--- a/cogip/tools/simulator/__main__.py
+++ b/cogip/tools/simulator/__main__.py
@@ -160,7 +160,6 @@ def main():
     controller.signal_new_robot_state.connect(robot_entity.new_robot_state)
     controller.signal_new_robot_state.connect(robot_final_entity.new_robot_state)
     controller.signal_new_robot_state.connect(win.game_view.new_robot_state)
-    controller.signal_new_dyn_obstacles.connect(robot_entity.set_dyn_obstacles)
 
     # Connect Controller signals to UI slots
     controller.signal_new_console_text.connect(win.log_text.append)

--- a/cogip/tools/simulator/serialcontroller.py
+++ b/cogip/tools/simulator/serialcontroller.py
@@ -129,8 +129,6 @@ class SerialController(QtCore.QObject):
 
                 self.get_state()
 
-                self.get_dyn_obstacles()
-
             logger.debug("main_loop: lock released")
 
         # Close the serial port before exiting the thread
@@ -195,31 +193,6 @@ class SerialController(QtCore.QObject):
                     continue
                 self.last_cycle = state.cycle
                 self.signal_new_robot_state.emit(state)
-            except ValidationError:
-                attempt += 1
-                self.signal_new_console_text.emit(line)
-                # print(f"parse failed: {line}")
-
-    def get_dyn_obstacles(self):
-        """
-        Get dynamic obstacles from the robot and send it to the robot entity.
-        """
-        self.serial_port.write(b"_dyn_obstacles\n")
-
-        obstacles_found = False
-        attempt = 0
-        while (not self.exiting and not obstacles_found
-                and attempt < SerialController.max_parse_attemps):
-            line = self.serial_port.readline().rstrip().decode(errors="ignore")
-            if len(line) == 0:
-                continue
-            if line[0] in [">", "_"]:
-                continue
-            try:
-                dyn_obstacles = DynObstacleList.parse_raw(line)
-                self.signal_new_dyn_obstacles.emit(dyn_obstacles)
-                obstacles_found = True
-                # print(dyn_obstacles)
             except ValidationError:
                 attempt += 1
                 self.signal_new_console_text.emit(line)

--- a/cogip/widgets/gameview.py
+++ b/cogip/widgets/gameview.py
@@ -12,6 +12,7 @@ from PySide2.QtCore import Slot as qtSlot
 
 from cogip.entities.asset import AssetEntity
 from cogip.entities.obstacle import ObstacleEntity
+from cogip.entities.path import PathEntity
 from cogip.models import models
 
 
@@ -65,6 +66,8 @@ class GameView(QtWidgets.QWidget):
         # Create root entity
         self.root_entity = Qt3DCore.QEntity()
         self.view.setRootEntity(self.root_entity)
+
+        self.path: PathEntity = PathEntity(parent=self.root_entity)
 
         # Init Camera
         self.camera_entity: Qt3DRender.QCamera = self.view.camera()
@@ -239,6 +242,19 @@ class GameView(QtWidgets.QWidget):
         """
         self.plane_intersection = None
         self.new_move_delta.emit(None)
+
+    @qtSlot(models.RobotState)
+    def new_robot_state(self, new_state: models.RobotState) -> None:
+        """
+        Qt slot called when robot state is updated.
+        Update computed path.
+
+        Arguments:
+            new_state: new robot state
+        """
+        for vertex in new_state.path:
+            vertex.z = 20
+        self.path.set_points(new_state.path)
 
 
 def create_ligth_entity(x: float, y: float, z: float) -> Qt3DCore.QEntity:

--- a/docs/developers/modules/cogip/entities/line.md
+++ b/docs/developers/modules/cogip/entities/line.md
@@ -1,0 +1,5 @@
+::: cogip.entities.line
+    rendering:
+      show_source: true
+      show_root_heading: no
+      heading_level: 1

--- a/docs/developers/modules/cogip/entities/path.md
+++ b/docs/developers/modules/cogip/entities/path.md
@@ -1,0 +1,5 @@
+::: cogip.entities.path
+    rendering:
+      show_source: true
+      show_root_heading: no
+      heading_level: 1

--- a/docs/usage/simulator.md
+++ b/docs/usage/simulator.md
@@ -6,18 +6,18 @@ is launched with:
 $ simulator
 ```
 
-The simulator can be used with the native firmware or connected via serial port to the robot.
+The simulator can be used with the native firmware or connected via serial port to the robot (locally or on a remote device).
 
-By default, the serial ports are scanned, and if found, the first port will be used to try to connect to the robot (see [Robot Mode](#robot-mode)).
+By default, the serial ports are scanned, and if found, the first port will be used to try to connect to the robot (see [Monitoring Mode](#monitor-mode)).
 
-If no serial port is found, it will launch the default native firmware (see [Native Mode](#native-mode)).
+If no serial port is found, it will launch the default native firmware (see [Simulation Mode](#simulation-mode)).
 
 
 ## Command line options
 
 ```bash
 $ simulator --help
-usage: simulator [-h] [-D UART_DEVICE | -B NATIVE_BINARY]
+usage: simulator [-h] [-D UART_DEVICE | -B NATIVE_BINARY | -r REMOTE] [-n]
 
 Launch COGIP Simulator.
 
@@ -26,13 +26,16 @@ optional arguments:
   -D UART_DEVICE, --device UART_DEVICE
                         Specify UART device
   -B NATIVE_BINARY, --binary NATIVE_BINARY
-                        Specify native board binary compiled in calibration mode
+                        Specify native binary compiled with shell menus enabled
+  -r REMOTE, --remote REMOTE
+                        Remote device providing the serial port connected to the robot
+  -n, --no-wait         Do not wait for the firmware start sequence
 ```
 
-## Native Mode
+## Simulation Mode
 
 The default native firmware is:
-`submodules/mcu-firmware/applications/cogip2019-cortex/bin/cogip2019-cortex-native/cortex.elf`
+`submodules/mcu-firmware/applications/cup2019/bin/cogip-native/cortex.elf`
 
 It can be changed using:
 
@@ -42,13 +45,22 @@ It can be changed using:
 
 Using these options will disable serial port scan.
 
-## Robot Mode
+## Monitoring Mode
 
 If a robot is connected to a serial port, the first port will be used by default.
 
 The default serial port can be modified using the environment variable `DEFAULT_UART`.
 
 To specify an other serial port, use the `-D/--device <UART_DEVICE>` CLI option.
+
+## Remote Mode
+
+If a robot is connected to a serial port on a remote device, use `-r/--remote <REMOTE>`
+to specify this device.
+
+The argument must identify a device that can be connected using `ssh` without password.
+
+`picocom` must be installed on the remote device. Serial port must be `/dev/ttyACM0`.
 
 ## Environment Variables
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
           - asset.py: developers/modules/cogip/entities/asset.md
           - dynobstacle.py: developers/modules/cogip/entities/dynobstacle.md
           - impact.py: developers/modules/cogip/entities/impact.md
+          - line.py: developers/modules/cogip/entities/line.md
           - obstacle.py: developers/modules/cogip/entities/obstacle.md
           - robot.py: developers/modules/cogip/entities/robot.md
           - sensor.py: developers/modules/cogip/entities/sensor.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
           - impact.py: developers/modules/cogip/entities/impact.md
           - line.py: developers/modules/cogip/entities/line.md
           - obstacle.py: developers/modules/cogip/entities/obstacle.md
+          - path.py: developers/modules/cogip/entities/path.md
           - robot.py: developers/modules/cogip/entities/robot.md
           - sensor.py: developers/modules/cogip/entities/sensor.md
         - widgets:


### PR DESCRIPTION
Add -n/--no-wait option to allows to start monitoring the robot without waiting for the initialization sequence.
Add -r/--remote option to specify a remote device providing the serial port connected to the robot.
Add circle obstacles support.
Update rectangle obstacles support.
Integrate dyn_obstacles in RobotState.
Support and display expected path.
