### PR TITLE
193 Add multi-waypoint path API via shared memory

### DIFF
--- a/.github/workflows/code-quality-workflow.yml
+++ b/.github/workflows/code-quality-workflow.yml
@@ -24,9 +24,9 @@ jobs:
         with:
           python-version: '3.13'
       - name: Install dependencies
-        run: pip install PySide6
+        run: pip install PySide6==6.10.0
       - name: Run qmllint
-        run: pyside6-qmllint cogip/tools/monitor/*.qml
+        run: pyside6-qmllint -i cogip/tools/monitor/qmldir cogip/tools/monitor/*.qml
       - name: Check qml format
         run: |
           pyside6-qmlformat --inplace cogip/tools/monitor/*.qml

--- a/cogip/cpp/libraries/shared_memory/SharedMemory.cpp
+++ b/cogip/cpp/libraries/shared_memory/SharedMemory.cpp
@@ -52,6 +52,7 @@ SharedMemory::SharedMemory(const std::string& name, bool owner):
             data_->lidar_data[i][1] = -1;
             data_->lidar_data[i][2] = -1;
         }
+        data_->path_controller_id = -1;
     }
 
     for (const auto& [lock, name] : lock2str) {

--- a/cogip/cpp/libraries/shared_memory/binding.cpp
+++ b/cogip/cpp/libraries/shared_memory/binding.cpp
@@ -151,6 +151,10 @@ NB_MODULE(shared_memory, m) {
              "Get PoseOrder object wrapping the shared memory avoidance_pose_order structure.")
         .def("get_avoidance_path", &SharedMemory::getAvoidancePath, nb::rv_policy::reference_internal,
              "Get PoseOrderList object wrapping the shared memory avoidance_path structure.")
+        .def_prop_rw("path_controller_id",
+            [](SharedMemory& self) { return self.getData()->path_controller_id; },
+            [](SharedMemory& self, int32_t id) { self.getData()->path_controller_id = id; },
+            "Controller to set before path execution, -1 = no change")
         .def("get_sim_camera_data",
              [](SharedMemory &self) -> nb::ndarray<uint8_t, nb::numpy, nb::shape<SIM_CAMERA_HEIGHT, SIM_CAMERA_WIDTH, 4>> {
                  auto &data = self.getSimCameraData();

--- a/cogip/cpp/libraries/shared_memory/binding.cpp
+++ b/cogip/cpp/libraries/shared_memory/binding.cpp
@@ -155,6 +155,22 @@ NB_MODULE(shared_memory, m) {
             [](SharedMemory& self) { return self.getData()->path_controller_id; },
             [](SharedMemory& self, int32_t id) { self.getData()->path_controller_id = id; },
             "Controller to set before path execution, -1 = no change")
+        .def_prop_rw("has_pose_start",
+            [](SharedMemory& self) { return self.getData()->has_pose_start; },
+            [](SharedMemory& self, bool has) { self.getData()->has_pose_start = has; },
+            "Whether pose_start should be sent to firmware")
+        .def_prop_rw("pose_start_x",
+            [](SharedMemory& self) { return self.getData()->pose_start.x; },
+            [](SharedMemory& self, double x) { self.getData()->pose_start.x = x; },
+            "X coordinate of the start pose")
+        .def_prop_rw("pose_start_y",
+            [](SharedMemory& self) { return self.getData()->pose_start.y; },
+            [](SharedMemory& self, double y) { self.getData()->pose_start.y = y; },
+            "Y coordinate of the start pose")
+        .def_prop_rw("pose_start_angle",
+            [](SharedMemory& self) { return self.getData()->pose_start.angle; },
+            [](SharedMemory& self, double angle) { self.getData()->pose_start.angle = angle; },
+            "Orientation angle of the start pose")
         .def("get_sim_camera_data",
              [](SharedMemory &self) -> nb::ndarray<uint8_t, nb::numpy, nb::shape<SIM_CAMERA_HEIGHT, SIM_CAMERA_WIDTH, 4>> {
                  auto &data = self.getSimCameraData();

--- a/cogip/cpp/libraries/shared_memory/include/shared_memory/shared_data.hpp
+++ b/cogip/cpp/libraries/shared_memory/include/shared_memory/shared_data.hpp
@@ -42,6 +42,7 @@ typedef struct {
     models::pose_order_t avoidance_new_pose_order;  ///< New pose order for the avoidance process
     models::pose_order_t avoidance_pose_order;  ///< Current pose order for the avoidance process
     models::pose_order_list_t avoidance_path;  ///< Path for the avoidance process
+    int32_t path_controller_id;      ///< Controller to set before path execution, -1 = no change
     uint8_t sim_camera_data[SIM_CAMERA_WIDTH * SIM_CAMERA_HEIGHT * 4];  ///< Simulated camera data in RGBA format
 } shared_data_t;
 

--- a/cogip/cpp/libraries/shared_memory/include/shared_memory/shared_data.hpp
+++ b/cogip/cpp/libraries/shared_memory/include/shared_memory/shared_data.hpp
@@ -43,6 +43,8 @@ typedef struct {
     models::pose_order_t avoidance_pose_order;  ///< Current pose order for the avoidance process
     models::pose_order_list_t avoidance_path;  ///< Path for the avoidance process
     int32_t path_controller_id;      ///< Controller to set before path execution, -1 = no change
+    bool has_pose_start;             ///< True if pose_start should be sent to firmware
+    models::pose_t pose_start;       ///< Start pose to send to firmware
     uint8_t sim_camera_data[SIM_CAMERA_WIDTH * SIM_CAMERA_HEIGHT * 4];  ///< Simulated camera data in RGBA format
 } shared_data_t;
 

--- a/cogip/tools/beaconcam/codecs.py
+++ b/cogip/tools/beaconcam/codecs.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from enum import StrEnum
 
 
-class VideoCodec(str, Enum):
+class VideoCodec(StrEnum):
     """Video codecs supported by our cameras"""
 
     mjpg = "MJPG"

--- a/cogip/tools/copilot/controller.py
+++ b/cogip/tools/copilot/controller.py
@@ -3,6 +3,5 @@ from enum import IntEnum
 
 class ControllerEnum(IntEnum):
     QUADPID = 0
-    ANGULAR_SPEED_TEST = 1
-    LINEAR_SPEED_TEST = 2
-    LINEAR_POSE_DISABLED = 3
+    QUADPID_TRACKER = 1
+    TRACKER_SPEED_TUNING = 2

--- a/cogip/tools/copilot/copilot.py
+++ b/cogip/tools/copilot/copilot.py
@@ -12,6 +12,7 @@ from cogip.cpp.libraries.shared_memory import LockName, SharedMemory, WritePrior
 from cogip.models.actuators import ActuatorsKindEnum
 from cogip.protobuf import (
     PB_ActuatorState,
+    PB_Controller,
     PB_EmergencyStopStatus,
     PB_ParameterGetResponse,
     PB_ParameterSetResponse,
@@ -457,13 +458,26 @@ class Copilot:
 
     async def new_path_event_loop(self):
         """
-        Async worker watching for new path orders in shared memory.
-        When a new path is available, all waypoints are sent to the firmware using the path API.
+        Async worker watching for shared memory updates from planner.
+        Handles set_controller and path commands. Both use the same
+        AvoidancePath lock so that this single event loop processes them
+        sequentially, guaranteeing CAN message ordering (set_controller
+        always arrives before path_start on the firmware).
         """
         logger.info("Copilot: Task New Path Event Watcher Loop started")
         try:
             while True:
                 await asyncio.to_thread(self.shared_avoidance_path_lock.wait_update)
+
+                # Read controller from shared memory (sticky value, always sent if >= 0)
+                controller_id = self.shared_memory.path_controller_id
+                if controller_id >= 0:
+                    logger.info(f"Copilot: Setting controller {controller_id}")
+                    pb_controller = PB_Controller()
+                    pb_controller.id = controller_id
+                    await self.pbcom.send_can_message(controller_uuid, pb_controller)
+
+                # Read path from shared memory
                 path_size = len(self.shared_avoidance_path)
                 if path_size == 0:
                     continue

--- a/cogip/tools/copilot/copilot.py
+++ b/cogip/tools/copilot/copilot.py
@@ -459,10 +459,10 @@ class Copilot:
     async def new_path_event_loop(self):
         """
         Async worker watching for shared memory updates from planner.
-        Handles set_controller and path commands. Both use the same
-        AvoidancePath lock so that this single event loop processes them
-        sequentially, guaranteeing CAN message ordering (set_controller
-        always arrives before path_start on the firmware).
+        Handles set_controller, pose_start and path commands. All use the
+        same AvoidancePath lock so that this single event loop processes
+        them sequentially, guaranteeing CAN message ordering on the
+        firmware side.
         """
         logger.info("Copilot: Task New Path Event Watcher Loop started")
         try:
@@ -476,6 +476,16 @@ class Copilot:
                     pb_controller = PB_Controller()
                     pb_controller.id = controller_id
                     await self.pbcom.send_can_message(controller_uuid, pb_controller)
+
+                # Read pose_start from shared memory (one-shot, consumed after sending)
+                if self.shared_memory.has_pose_start:
+                    logger.info("Copilot: Sending pose_start")
+                    pb_start_pose = PB_PathPose()
+                    pb_start_pose.pose.x = int(self.shared_memory.pose_start_x)
+                    pb_start_pose.pose.y = int(self.shared_memory.pose_start_y)
+                    pb_start_pose.pose.O = int(self.shared_memory.pose_start_angle)
+                    await self.pbcom.send_can_message(pose_start_uuid, pb_start_pose)
+                    self.shared_memory.has_pose_start = False
 
                 # Read path from shared memory
                 path_size = len(self.shared_avoidance_path)

--- a/cogip/tools/copilot/copilot.py
+++ b/cogip/tools/copilot/copilot.py
@@ -469,9 +469,10 @@ class Copilot:
             while True:
                 await asyncio.to_thread(self.shared_avoidance_path_lock.wait_update)
 
-                # Read controller from shared memory (sticky value, always sent if >= 0)
+                # Read controller from shared memory (consumed after sending)
                 controller_id = self.shared_memory.path_controller_id
                 if controller_id >= 0:
+                    self.shared_memory.path_controller_id = -1
                     logger.info(f"Copilot: Setting controller {controller_id}")
                     pb_controller = PB_Controller()
                     pb_controller.id = controller_id
@@ -487,7 +488,7 @@ class Copilot:
                     await self.pbcom.send_can_message(pose_start_uuid, pb_start_pose)
                     self.shared_memory.has_pose_start = False
 
-                # Read path from shared memory
+                # Read path from shared memory (consumed after sending)
                 path_size = len(self.shared_avoidance_path)
                 if path_size == 0:
                     continue
@@ -505,6 +506,9 @@ class Copilot:
                     pb_pose_order = PB_PathPose()
                     pose_order.copy_pb(pb_pose_order)
                     await self.pbcom.send_can_message(path_add_point_uuid, pb_pose_order)
+
+                # Clear shared memory path to avoid resending on next wake-up
+                self.shared_avoidance_path.clear()
 
                 # Start path execution
                 await self.pbcom.send_can_message(path_start_uuid, None)

--- a/cogip/tools/copilot/sio_events.py
+++ b/cogip/tools/copilot/sio_events.py
@@ -10,7 +10,6 @@ from cogip.models import FirmwareParameter
 from cogip.models.actuators import ActuatorCommand, PositionalActuatorCommand
 from cogip.protobuf import (
     PB_ActuatorCommand,
-    PB_Controller,
     PB_ParameterGetRequest,
     PB_ParameterSetRequest,
     PB_PathPose,
@@ -99,13 +98,10 @@ class SioEvents(socketio.AsyncClientNamespace):
     async def on_pose_start(self, data: dict[str, Any]):
         """
         Callback on pose start (from planner).
-        Forward to mcu-firmware.
+        CAN is now sent via shared memory event loop for ordering guarantee.
+        SIO is only kept for server/dashboard state tracking.
         """
-        logger.info(f"[SIO] Pose start: {data}")
-        start_pose = models.PathPose.model_validate(data)
-        pb_start_pose = PB_PathPose()
-        start_pose.copy_pb(pb_start_pose)
-        await self.copilot.pbcom.send_can_message(copilot.pose_start_uuid, pb_start_pose)
+        logger.info(f"[SIO] Pose start (info only): {data}")
 
     async def on_pose_order(self, data: dict[str, Any]):
         """
@@ -168,11 +164,10 @@ class SioEvents(socketio.AsyncClientNamespace):
     async def on_set_controller(self, controller: int):
         """
         Callback on set_controller message.
-        Forward to firmware.
+        CAN is now sent via shared memory event loop for ordering guarantee.
+        SIO is only kept for server/dashboard state tracking.
         """
-        pb_controller = PB_Controller()
-        pb_controller.id = controller
-        await self.copilot.pbcom.send_can_message(copilot.controller_uuid, pb_controller)
+        logger.info(f"[SIO] Set controller (info only): {controller}")
 
     async def on_game_start(self):
         """

--- a/cogip/tools/monitor/ConfigWindow.qml
+++ b/cogip/tools/monitor/ConfigWindow.qml
@@ -7,6 +7,8 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import QtQuick.Window
 
+import "."
+
 Window {
     id: configWindow
 

--- a/cogip/tools/monitor/Wizard.qml
+++ b/cogip/tools/monitor/Wizard.qml
@@ -5,6 +5,8 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import QtQuick.Window
 
+import "."
+
 Dialog {
     id: wizardDialog
 

--- a/cogip/tools/monitor/main.qml
+++ b/cogip/tools/monitor/main.qml
@@ -5,6 +5,8 @@ import QtQuick.Controls
 import QtQuick.Dialogs
 import QtQuick.Layouts
 
+import "."
+
 ApplicationWindow {
     id: window
 

--- a/cogip/tools/monitor/qmldir
+++ b/cogip/tools/monitor/qmldir
@@ -1,0 +1,11 @@
+module Monitor
+ConfigWindow 1.0 ConfigWindow.qml
+DoubleSpinBox 1.0 DoubleSpinBox.qml
+Footer 1.0 Footer.qml
+LidarRayNode 1.0 LidarRayNode.qml
+Obstacle 1.0 Obstacle.qml
+ObstacleWindow 1.0 ObstacleWindow.qml
+Polyline3D 1.0 Polyline3D.qml
+Scene 1.0 Scene.qml
+SideMenu 1.0 SideMenu.qml
+Wizard 1.0 Wizard.qml

--- a/cogip/tools/planner/planner.py
+++ b/cogip/tools/planner/planner.py
@@ -412,6 +412,17 @@ class Planner:
         if self.controller == new_controller and not force:
             return
         self.controller = new_controller
+        # Write to shared memory using the same lock as path data.
+        # Using the same lock and event loop guarantees CAN message ordering:
+        # the copilot processes set_controller before path_start because both
+        # go through a single sequential event loop. Using separate locks would
+        # create two independent event loops with no ordering guarantee.
+        if self.shared_avoidance_path_lock is not None and self.shared_memory is not None:
+            self.shared_avoidance_path_lock.start_writing()
+            self.shared_memory.path_controller_id = self.controller.value
+            self.shared_avoidance_path_lock.finish_writing()
+            self.shared_avoidance_path_lock.post_update()
+        # Also emit via SIO for server/dashboard state tracking
         await self.sio_ns.emit("set_controller", self.controller.value)
 
     async def set_pose_start(self, pose_start: models.Pose):
@@ -456,6 +467,7 @@ class Planner:
                 self.shared_avoidance_path.append()
                 shared_pose = self.shared_avoidance_path[self.shared_avoidance_path.size() - 1]
                 path_pose.to_shared(shared_pose)
+
             self.shared_avoidance_path_lock.finish_writing()
             self.shared_avoidance_path_lock.post_update()
 

--- a/cogip/tools/planner/planner.py
+++ b/cogip/tools/planner/planner.py
@@ -179,6 +179,8 @@ class Planner:
         )
         self.playing: bool = False
         self._pose_order: pose.Pose | None = None
+        self._path_points: list[models.PathPose] = []  # Waypoints for new path API
+        self._sending_path: bool = False  # Flag to ignore pose_reached while configuring a new path
         self.pose_reached: bool = True
         self.blocked_counter: int = 0
         self.controller = self.default_controller
@@ -425,6 +427,41 @@ class Planner:
         self.shared_pose_current_buffer.push(pose_start.x, pose_start.y, pose_start.O)
         await self.sio_ns.emit("pose_start", pose_start.model_dump())
 
+    async def path_reset(self):
+        """
+        Reset the path (clear all waypoints).
+        """
+        logger.info("Planner: path_reset() - setting _sending_path=True")
+        self._sending_path = True  # Ignore pose_reached until path_start()
+        self._path_points.clear()
+
+    async def path_add_point(self, path_pose: models.PathPose):
+        """
+        Add a waypoint to the path.
+        """
+        logger.info(f"Planner: path_add_point({path_pose})")
+        self._path_points.append(path_pose)
+
+    async def path_start(self):
+        """
+        Start path execution on the firmware.
+        Writes the path to shared memory and signals the copilot via post_update().
+        The copilot's new_path_event_loop() will read the path and send CAN messages.
+        """
+        logger.info("Planner: path_start()")
+        if self._path_points and self.shared_avoidance_path_lock is not None and self.shared_avoidance_path is not None:
+            self.shared_avoidance_path_lock.start_writing()
+            self.shared_avoidance_path.clear()
+            for path_pose in self._path_points:
+                self.shared_avoidance_path.append()
+                shared_pose = self.shared_avoidance_path[self.shared_avoidance_path.size() - 1]
+                path_pose.to_shared(shared_pose)
+            self.shared_avoidance_path_lock.finish_writing()
+            self.shared_avoidance_path_lock.post_update()
+
+        logger.info("Planner: path_start() done - setting _sending_path=False")
+        self._sending_path = False  # Now ready to receive pose_reached
+
     @property
     def pose_order(self) -> pose.Pose | None:
         return self._pose_order
@@ -444,7 +481,13 @@ class Planner:
         """
         Set pose reached for a robot.
         """
-        logger.info("Planner: set_pose_reached()")
+        action_name = self.action.name if self.action else None
+        logger.info(f"Planner: set_pose_reached() [_sending_path={self._sending_path}, action={action_name}]")
+
+        # Ignore pose_reached signals while configuring a new path
+        if self._sending_path:
+            logger.info("Planner: set_pose_reached() ignored - path is being configured")
+            return
 
         # Set pose reached
         if not self.pose_reached and (pose_order := self.pose_order):
@@ -455,6 +498,7 @@ class Planner:
 
         self.pose_reached = True
         if (action := self.action) and len(self.action.poses) == 0:
+            logger.info(f"Planner: set_pose_reached() clearing action '{action.name}' (poses empty)")
             self.action = None
             await action.act_after_action()
 
@@ -499,7 +543,13 @@ class Planner:
             # If no pose left in current action, get and set new action
             if not self.pose_order and (new_action := await self.strategy.get_next_action()):
                 await self.set_action(new_action)
-                if not self.pose_order:
+                # Only auto-advance if no action is waiting for completion.
+                # Actions using path API will have self.action set but pose_order None,
+                # they need to wait for firmware pose_reached signal.
+                action_name = self.action.name if self.action else None
+                logger.info(f"Planner: next_pose() after set_action: pose={self.pose_order}, action={action_name}")
+                if not self.pose_order and self.action is None:
+                    logger.info("Planner: next_pose() -> auto-advance (no action)")
                     asyncio.create_task(self.set_pose_reached())
         except Exception as exc:  # noqa
             logger.warning(f"Planner: Unknown exception {exc}")
@@ -513,8 +563,12 @@ class Planner:
         logger.info(f"Planner: set action '{action.name}'")
         self.pose_order = None
         self.action = action
+        action_name = self.action.name if self.action else None
+        logger.info(f"Planner: set_action() calling act_before_action, action={action_name}")
         await self.action.act_before_action()
+        logger.info(f"Planner: set_action() act_before_action done, action={action_name}")
         await self.next_pose_in_action()
+        logger.info(f"Planner: set_action() done, action={action_name}")
 
     async def blocked(self):
         """
@@ -526,7 +580,7 @@ class Planner:
                 await self.set_action(new_action)
             await current_action.recycle()
             self.strategy.append(current_action)
-            if not self.pose_order:
+            if not self.pose_order and self.action is None:
                 asyncio.create_task(self.set_pose_reached())
 
     async def update_obstacles(self):

--- a/cogip/tools/planner/planner.py
+++ b/cogip/tools/planner/planner.py
@@ -436,6 +436,17 @@ class Planner:
         # When the firmware receives a pose start, it does not send its updated pose current,
         # so do it here.
         self.shared_pose_current_buffer.push(pose_start.x, pose_start.y, pose_start.O)
+
+        # Write to shared memory using the same lock as set_controller and path.
+        if self.shared_avoidance_path_lock is not None and self.shared_memory is not None:
+            self.shared_avoidance_path_lock.start_writing()
+            self.shared_memory.has_pose_start = True
+            self.shared_memory.pose_start_x = pose_start.x
+            self.shared_memory.pose_start_y = pose_start.y
+            self.shared_memory.pose_start_angle = pose_start.O
+            self.shared_avoidance_path_lock.finish_writing()
+            self.shared_avoidance_path_lock.post_update()
+        # Also emit via SIO for server/dashboard state tracking
         await self.sio_ns.emit("pose_start", pose_start.model_dump())
 
     async def path_reset(self):

--- a/cogip/tools/planner/planner.py
+++ b/cogip/tools/planner/planner.py
@@ -401,10 +401,8 @@ class Planner:
     @property
     def default_controller(self) -> ControllerEnum:
         match self.shared_properties.strategy:
-            case StrategyEnum.PidAngularSpeedTest:
-                return ControllerEnum.ANGULAR_SPEED_TEST
-            case StrategyEnum.PidLinearSpeedTest:
-                return ControllerEnum.LINEAR_SPEED_TEST
+            case StrategyEnum.PidAngularSpeedTest | StrategyEnum.PidLinearSpeedTest:
+                return ControllerEnum.TRACKER_SPEED_TUNING
             case _:
                 return ControllerEnum.QUADPID
 

--- a/cogip/tools/planner/planner.py
+++ b/cogip/tools/planner/planner.py
@@ -408,24 +408,22 @@ class Planner:
             case _:
                 return ControllerEnum.QUADPID
 
-    async def set_controller(self, new_controller: ControllerEnum, force: bool = False):
+    async def set_controller(self, new_controller: ControllerEnum, force: bool = False, notify: bool = True):
         if self.controller == new_controller and not force:
             return
         self.controller = new_controller
         # Write to shared memory using the same lock as path data.
-        # Using the same lock and event loop guarantees CAN message ordering:
-        # the copilot processes set_controller before path_start because both
-        # go through a single sequential event loop. Using separate locks would
-        # create two independent event loops with no ordering guarantee.
         if self.shared_avoidance_path_lock is not None and self.shared_memory is not None:
             self.shared_avoidance_path_lock.start_writing()
             self.shared_memory.path_controller_id = self.controller.value
             self.shared_avoidance_path_lock.finish_writing()
-            self.shared_avoidance_path_lock.post_update()
+            # Only notify if not part of a path sequence (path_start will notify)
+            if notify:
+                self.shared_avoidance_path_lock.post_update()
         # Also emit via SIO for server/dashboard state tracking
         await self.sio_ns.emit("set_controller", self.controller.value)
 
-    async def set_pose_start(self, pose_start: models.Pose):
+    async def set_pose_start(self, pose_start: models.Pose, notify: bool = True):
         """
         Set the start position of the robot for the next game.
         """
@@ -445,7 +443,9 @@ class Planner:
             self.shared_memory.pose_start_y = pose_start.y
             self.shared_memory.pose_start_angle = pose_start.O
             self.shared_avoidance_path_lock.finish_writing()
-            self.shared_avoidance_path_lock.post_update()
+            # Only notify if not part of a path sequence (path_start will notify)
+            if notify:
+                self.shared_avoidance_path_lock.post_update()
         # Also emit via SIO for server/dashboard state tracking
         await self.sio_ns.emit("pose_start", pose_start.model_dump())
 


### PR DESCRIPTION
## Summary

Add a multi-waypoint path API that sends all waypoints to the firmware at once via shared memory (planner -> copilot -> CAN).

## Changes

- **copilot: align controller enum with firmware** - Sync ControllerEnum with current PB_Controller.proto (QUADPID_TRACKER, TRACKER_SPEED_TUNING)
- **planner: use TRACKER_SPEED_TUNING for PID test strategies** - The firmware merged the two separate speed test chains into a single TRACKER_SPEED_TUNING chain
- **copilot: add path API for multi-waypoint navigation** - Add CAN UUIDs (path_reset, path_add_point, path_start, path_complete) and new_path_event_loop() in the copilot
- **planner: add path API** - Add path_reset(), path_add_point(), path_start() methods and _sending_path guard
- **copilot: pass set_controller through shared memory** - Move set_controller from SIO to shared memory to guarantee CAN message ordering
- **copilot: pass pose_start through shared memory** - Complete the migration for ordering guarantee
- **copilot: fix shared memory race conditions** - Consume data after reading to prevent resending stale values

## Design

The existing set_target_pose flow (SIO -> avoidance -> firmware) is unchanged. The new path API is an alternative for actions that need to send multiple waypoints at once.

The shared memory migration for set_controller and pose_start improves reliability by guaranteeing CAN message ordering through a single sequential event loop in the copilot.