### PR TITLE
Add OTOS calibration tool

### DIFF
--- a/cogip/cpp/libraries/shared_memory/WritePriorityLock.cpp
+++ b/cogip/cpp/libraries/shared_memory/WritePriorityLock.cpp
@@ -11,6 +11,8 @@
 #include <stdexcept>
 #include <iostream>
 #include <time.h>
+#include <signal.h>
+#include <errno.h>
 
 namespace cogip {
 
@@ -29,14 +31,14 @@ WritePriorityLock::WritePriorityLock(const std::string& name, bool owner):
     consumer_count_shm_name_("/" + name_ + "_consumer_count"),
     sem_mutex_(nullptr),
     sem_write_lock_(nullptr),
-    sem_update_(nullptr),
+    my_update_sem_(nullptr),
     sem_register_(nullptr),
     reader_shm_fd_(-1),
     write_request_shm_fd_(-1),
     consumer_count_shm_fd_(-1),
     reader_count_(nullptr),
     write_request_count_(nullptr),
-    consumer_count_(nullptr),
+    consumer_pids_(nullptr),
     debug_(false)
 {
     int shm_flags = O_RDWR;
@@ -66,17 +68,6 @@ WritePriorityLock::WritePriorityLock(const std::string& name, bool owner):
     }
     if (sem_write_lock_ == SEM_FAILED) {
         throw std::runtime_error("Failed to open write lock semaphore");
-    }
-
-    // Open or create the update semaphore
-    if (owner) {
-        sem_update_ = sem_open(update_name_.c_str(), O_CREAT | O_RDWR | O_TRUNC, 0666, 1);
-    }
-    else {
-        sem_update_ = sem_open(update_name_.c_str(), O_RDWR);
-    }
-    if (sem_update_ == SEM_FAILED) {
-        throw std::runtime_error("Failed to open update semaphore");
     }
 
     // Open or create the register semaphore
@@ -125,12 +116,12 @@ WritePriorityLock::WritePriorityLock(const std::string& name, bool owner):
         throw std::runtime_error("Failed to open shared memory for consumer count");
     }
     if (owner_) {
-        if (ftruncate(consumer_count_shm_fd_, sizeof(int)) < 0) {
+        if (ftruncate(consumer_count_shm_fd_, MAX_CONSUMERS * sizeof(pid_t)) < 0) {
             throw std::runtime_error("Failed to truncate shared memory for consumer count");
         }
     }
-    consumer_count_ = static_cast<int*>(mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE, MAP_SHARED, consumer_count_shm_fd_, 0));
-    if (consumer_count_ == MAP_FAILED) {
+    consumer_pids_ = static_cast<pid_t*>(mmap(NULL, MAX_CONSUMERS * sizeof(pid_t), PROT_READ | PROT_WRITE, MAP_SHARED, consumer_count_shm_fd_, 0));
+    if (consumer_pids_ == MAP_FAILED) {
         throw std::runtime_error("Failed to map shared memory for consumer count");
     }
     if (owner_) {
@@ -142,11 +133,31 @@ WritePriorityLock::WritePriorityLock(const std::string& name, bool owner):
 WritePriorityLock::~WritePriorityLock() {
     if (registered_consumer_) {
         sem_wait(sem_register_);
-        (*consumer_count_)--;
+        pid_t current_pid = getpid();
+        for (int i = 0; i < MAX_CONSUMERS; ++i) {
+            if (consumer_pids_[i] == current_pid) {
+                consumer_pids_[i] = 0;
+                break;
+            }
+        }
         sem_post(sem_register_);
+
+        if (my_update_sem_ != nullptr) {
+            sem_close(my_update_sem_);
+            sem_unlink(my_update_sem_name_.c_str());
+        }
     }
-    if (consumer_count_ != nullptr) {
-        munmap(consumer_count_, sizeof(int));
+
+    // Close cached semaphores
+    for (auto& pair : update_sems_cache_) {
+        if (pair.second != nullptr) {
+            sem_close(pair.second);
+        }
+    }
+    update_sems_cache_.clear();
+
+    if (consumer_pids_ != nullptr) {
+        munmap(consumer_pids_, MAX_CONSUMERS * sizeof(pid_t));
     }
     if (write_request_count_ != nullptr) {
         munmap(write_request_count_, sizeof(int));
@@ -166,9 +177,6 @@ WritePriorityLock::~WritePriorityLock() {
     if (sem_register_ != nullptr) {
         sem_close(sem_register_);
     }
-    if (sem_update_ != nullptr) {
-        sem_close(sem_update_);
-    }
     if (sem_write_lock_ != nullptr) {
         sem_close(sem_write_lock_);
     }
@@ -177,7 +185,6 @@ WritePriorityLock::~WritePriorityLock() {
     }
     if (owner_) {
         sem_unlink(registration_name_.c_str());
-        sem_unlink(update_name_.c_str());
         sem_unlink(mutex_name_.c_str());
         sem_unlink(write_lock_name_.c_str());
         shm_unlink(reader_count_shm_name_.c_str());
@@ -240,32 +247,97 @@ void WritePriorityLock::finishWriting() {
 }
 
 void WritePriorityLock::registerConsumer() {
-    registered_consumer_ = true;
     sem_wait(sem_register_);
-    (*consumer_count_)++;
+    pid_t current_pid = getpid();
+    int empty_slot = -1;
+
+    for (int i = 0; i < MAX_CONSUMERS; ++i) {
+        pid_t pid = consumer_pids_[i];
+        if (pid != 0) {
+            // Check if process still exists
+            if (kill(pid, 0) == -1 && errno == ESRCH) {
+                // Process is dead, clean up
+                consumer_pids_[i] = 0;
+                std::string dead_sem_name = "/" + name_ + "_update_" + std::to_string(pid);
+                sem_unlink(dead_sem_name.c_str());
+                if (empty_slot == -1) empty_slot = i;
+            } else if (pid == current_pid) {
+                // Already registered
+                empty_slot = i;
+            }
+        } else if (empty_slot == -1) {
+            empty_slot = i;
+        }
+    }
+
+    if (empty_slot != -1) {
+        consumer_pids_[empty_slot] = current_pid;
+    } else {
+        sem_post(sem_register_);
+        throw std::runtime_error("Maximum number of consumers reached");
+    }
     sem_post(sem_register_);
+
+    my_update_sem_name_ = "/" + name_ + "_update_" + std::to_string(current_pid);
+    my_update_sem_ = sem_open(my_update_sem_name_.c_str(), O_CREAT, 0666, 0);
+    if (my_update_sem_ == SEM_FAILED) {
+        throw std::runtime_error("Failed to open specific update semaphore");
+    }
+
+    registered_consumer_ = true;
 }
 
 void WritePriorityLock::postUpdate() {
     if (debug_) {
-        int value;
-        sem_getvalue(sem_update_, &value);
-        std::cout << name_ << " postUpdate: count= " << *consumer_count_ << " sem_update_=" << value << std::endl;
+        std::cout << name_ << " postUpdate: start" << std::endl;
     }
-    for (int i = 0; i < *consumer_count_; ++i) {
-        sem_post(sem_update_);
+
+    for (int i = 0; i < MAX_CONSUMERS; ++i) {
+        pid_t pid = consumer_pids_[i];
+        if (pid != 0) {
+            sem_t* target_sem = nullptr;
+            auto it = update_sems_cache_.find(pid);
+            if (it != update_sems_cache_.end()) {
+                target_sem = it->second;
+            } else {
+                std::string target_sem_name = "/" + name_ + "_update_" + std::to_string(pid);
+                target_sem = sem_open(target_sem_name.c_str(), O_RDWR);
+                if (target_sem != SEM_FAILED) {
+                    update_sems_cache_[pid] = target_sem;
+                } else {
+                    target_sem = nullptr; // could be unlinked or not created yet
+                }
+            }
+
+            if (target_sem != nullptr) {
+                sem_post(target_sem);
+                if (debug_) {
+                    int value;
+                    sem_getvalue(target_sem, &value);
+                    std::cout << name_ << " postUpdate: pid=" << pid << " sem_update_=" << value << std::endl;
+                }
+            }
+        }
+    }
+
+    if (debug_) {
+        std::cout << name_ << " postUpdate: end" << std::endl;
     }
 }
 
 bool WritePriorityLock::waitUpdate(double timeout_seconds) {
+    if (my_update_sem_ == nullptr) {
+        throw std::runtime_error("waitUpdate called but consumer is not registered");
+    }
+
     if (debug_) {
         int value;
-        sem_getvalue(sem_update_, &value);
-        std::cout << name_ << " waitUpdate: count=" << *consumer_count_ << " sem_update_=" << value << std::endl;
+        sem_getvalue(my_update_sem_, &value);
+        std::cout << name_ << " waitUpdate: pid=" << getpid() << " sem_update_=" << value << std::endl;
     }
 
     if (timeout_seconds < 0) {
-        sem_wait(sem_update_);
+        sem_wait(my_update_sem_);
         if (debug_) std::cout << name_ << " waitUpdate: end" << std::endl;
         return true;
     } else {
@@ -284,7 +356,7 @@ bool WritePriorityLock::waitUpdate(double timeout_seconds) {
             ts.tv_nsec -= 1000000000;
         }
 
-        if (sem_timedwait(sem_update_, &ts) == -1) {
+        if (sem_timedwait(my_update_sem_, &ts) == -1) {
             return false;
         }
         if (debug_) std::cout << name_ << " waitUpdate: end" << std::endl;
@@ -297,11 +369,12 @@ void WritePriorityLock::reset() {
     *reader_count_ = 0;
     *write_request_count_ = 0;
     registered_consumer_ = false;
-    *consumer_count_ = 0;
+    for (int i = 0; i < MAX_CONSUMERS; ++i) {
+        consumer_pids_[i] = 0;
+    }
 
     sem_init(sem_mutex_, 1, 1);
     sem_init(sem_write_lock_, 1, 1);
-    sem_init(sem_update_, 1, 0);
     sem_init(sem_register_, 1, 1);
     if (debug_) std::cout << name_ << " reset: end" << std::endl;
 }

--- a/cogip/cpp/libraries/shared_memory/include/shared_memory/WritePriorityLock.hpp
+++ b/cogip/cpp/libraries/shared_memory/include/shared_memory/WritePriorityLock.hpp
@@ -4,6 +4,8 @@
 
 #include <semaphore.h>
 #include <string>
+#include <unordered_map>
+#include <sys/types.h>
 
 namespace cogip {
 
@@ -66,15 +68,18 @@ private:
     std::string consumer_count_shm_name_; ///< Name of the shared memory for consumer count.
     sem_t* sem_mutex_;              ///< Semaphore for synchronizing access to shared memory.
     sem_t* sem_write_lock_;         ///< Semaphore for ensuring write access priority.
-    sem_t* sem_update_;             ///< Semaphore for signaling updated data.
+    sem_t* my_update_sem_;          ///< Semaphore specific to this process for update signal.
+    std::string my_update_sem_name_;///< Name of my_update_sem_
     sem_t* sem_register_;           ///< Semaphore for consumer registration.
     int reader_shm_fd_;             ///< File descriptor for shared memory of reader count.
     int write_request_shm_fd_;      ///< File descriptor for shared memory of write request count.
     int consumer_count_shm_fd_;     ///< File descriptor for shared memory of consumer count.
     int* reader_count_;             ///< Shared memory pointer for reader count.
     int* write_request_count_;      ///< Shared memory pointer for writer request count.
-    int* consumer_count_;           ///< Shared memory pointer for consumer count.
+    pid_t* consumer_pids_;          ///< Shared memory pointer for consumer PIDs array.
+    std::unordered_map<pid_t, sem_t*> update_sems_cache_; ///< Cache of opened semaphores for postUpdate
     bool debug_;                    ///< Debug flag for logging.
+    static constexpr int MAX_CONSUMERS = 32; ///< Maximum number of registered consumers.
 };
 
 } // namespace shared_memory

--- a/cogip/models/__init__.py
+++ b/cogip/models/__init__.py
@@ -17,6 +17,7 @@ from .models import (  # noqa
     DynRoundObstacle,
     EmergencyStopStatus,
     MenuEntry,
+    MotionDirection,
     Obstacle,
     PathPose,
     Pose,

--- a/cogip/models/__init__.py
+++ b/cogip/models/__init__.py
@@ -33,3 +33,9 @@ from .odometry_calibration import (  # noqa
     EncoderDeltas,
     OdometryParameters,
 )
+from .otos_calibration import (  # noqa
+    OTOS_SCALAR_MAX,
+    OTOS_SCALAR_MIN,
+    OTOSCalibrationResult,
+    OTOSParameters,
+)

--- a/cogip/models/otos_calibration.py
+++ b/cogip/models/otos_calibration.py
@@ -1,0 +1,25 @@
+"""
+OTOS Calibration Models
+
+Pydantic models for the SparkFun OTOS sensor calibration scalars.
+"""
+
+from pydantic import BaseModel
+
+# Range accepted by the OTOS chip for both calibration scalars.
+OTOS_SCALAR_MIN = 0.872
+OTOS_SCALAR_MAX = 1.127
+
+
+class OTOSParameters(BaseModel):
+    """Current OTOS calibration scalars pulled from firmware."""
+
+    linear_scalar: float
+    angular_scalar: float
+
+
+class OTOSCalibrationResult(BaseModel):
+    """Computed scalars after a single calibration phase."""
+
+    linear_scalar: float
+    angular_scalar: float

--- a/cogip/tools/firmware_otos_calibration/__init__.py
+++ b/cogip/tools/firmware_otos_calibration/__init__.py
@@ -1,0 +1,5 @@
+import logging
+
+from cogip.utils.logger import Logger
+
+logger = Logger("cogip-otos-calibration", level=logging.WARNING)

--- a/cogip/tools/firmware_otos_calibration/__main__.py
+++ b/cogip/tools/firmware_otos_calibration/__main__.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+CLI entry point for the OTOS Calibration tool.
+
+Provides a command-line interface to calibrate the SparkFun OTOS sensor
+scalars through cogip-server (pose_order / pose_reached motion control
+and firmware parameter manager).
+"""
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Annotated
+
+import typer
+import yaml
+
+from cogip.models import FirmwareParametersGroup
+from cogip.tools.firmware_otos_calibration import logger
+from cogip.tools.firmware_otos_calibration.otos_calibration import OTOSCalibration
+
+
+def main_opt(
+    *,
+    server_url: Annotated[
+        str | None,
+        typer.Option(
+            "-s",
+            "--server-url",
+            help="cogip-server URL",
+            envvar="COGIP_SOCKETIO_SERVER_URL",
+        ),
+    ] = None,
+    robot_id: Annotated[
+        int,
+        typer.Option(
+            "-i",
+            "--id",
+            min=1,
+            help="Robot ID.",
+            envvar=["ROBOT_ID"],
+        ),
+    ] = 1,
+    debug: Annotated[
+        bool,
+        typer.Option(
+            "-d",
+            "--debug",
+            help="Turn on debug messages",
+            envvar="CALIBRATION_DEBUG",
+        ),
+    ] = False,
+):
+    if debug:
+        logger.setLevel(logging.DEBUG)
+
+    if not server_url:
+        server_url = f"http://localhost:809{robot_id}"
+
+    params_path = Path(__file__).with_name("otos_parameters.yaml")
+    parameters_data = yaml.safe_load(params_path.read_text())
+
+    parameters_group = FirmwareParametersGroup.model_validate(parameters_data["parameters"])
+
+    calibration = OTOSCalibration(server_url, parameters_group)
+    asyncio.run(calibration.run())
+
+
+def main():
+    """Run OTOS calibration tool."""
+    typer.run(main_opt)
+
+
+if __name__ == "__main__":
+    main()

--- a/cogip/tools/firmware_otos_calibration/calculator.py
+++ b/cogip/tools/firmware_otos_calibration/calculator.py
@@ -1,0 +1,72 @@
+"""
+OTOS Calibration Calculator.
+
+Pure math functions that derive a new OTOS calibration scalar from the
+commanded motion and the physically measured result.
+
+Both scalars correct a systematic bias between the OTOS-reported distance /
+rotation and the actual one. The control loop stops when OTOS reports it has
+reached the commanded value, so:
+
+    physical = OTOS_reported / current_scalar
+    new_scalar = current_scalar * (measured / commanded)
+
+Each function returns the clamped scalar together with a boolean telling the
+caller whether clamping actually kicked in (a sign that the sensor is more
+off than OTOS can compensate and the mechanical setup needs a look).
+"""
+
+from cogip.models.otos_calibration import OTOS_SCALAR_MAX, OTOS_SCALAR_MIN
+
+
+def _clamp(value: float) -> tuple[float, bool]:
+    clamped = max(OTOS_SCALAR_MIN, min(OTOS_SCALAR_MAX, value))
+    return clamped, clamped != value
+
+
+def compute_linear_scalar(
+    current_scalar: float,
+    commanded_mm: float,
+    measured_mm: float,
+) -> tuple[float, bool]:
+    """
+    Compute a new linear_scalar so that next time OTOS reports commanded_mm
+    the robot actually travels commanded_mm.
+
+    Args:
+        current_scalar: linear_scalar currently programmed in the OTOS chip.
+        commanded_mm: distance sent to the motion control (mm).
+        measured_mm: distance the operator measured after the motion (mm).
+
+    Returns:
+        (new_scalar, was_clamped). The second value is True if the result
+        had to be clamped to the OTOS allowed range [0.872, 1.127].
+    """
+    if commanded_mm == 0.0:
+        raise ValueError("commanded_mm must be non-zero")
+    raw = current_scalar * (measured_mm / commanded_mm)
+    return _clamp(raw)
+
+
+def compute_angular_scalar(
+    current_scalar: float,
+    commanded_deg: float,
+    measured_deg: float,
+) -> tuple[float, bool]:
+    """
+    Compute a new angular_scalar so that next time OTOS reports commanded_deg
+    the robot actually rotates commanded_deg.
+
+    Args:
+        current_scalar: angular_scalar currently programmed in the OTOS chip.
+        commanded_deg: rotation sent to the motion control (degrees).
+        measured_deg: rotation the operator measured after the motion (degrees).
+
+    Returns:
+        (new_scalar, was_clamped). The second value is True if the result
+        had to be clamped to the OTOS allowed range [0.872, 1.127].
+    """
+    if commanded_deg == 0.0:
+        raise ValueError("commanded_deg must be non-zero")
+    raw = current_scalar * (measured_deg / commanded_deg)
+    return _clamp(raw)

--- a/cogip/tools/firmware_otos_calibration/firmware_adapter.py
+++ b/cogip/tools/firmware_otos_calibration/firmware_adapter.py
@@ -110,7 +110,7 @@ class FirmwareAdapter:
         ) as progress:
             progress.add_task("", distance=distance_mm)
 
-            success = await self.goto(distance_mm, 0, 0, timeout=60.0)
+            success = await self.goto(distance_mm, 0, 0, timeout=10.0)
             if not success:
                 self._console.show_error("Straight line movement failed (timeout)")
                 return False

--- a/cogip/tools/firmware_otos_calibration/firmware_adapter.py
+++ b/cogip/tools/firmware_otos_calibration/firmware_adapter.py
@@ -1,0 +1,157 @@
+"""
+Firmware Adapter for OTOS Calibration
+
+Thin facade over the shared FirmwareParameterManager and the motion control
+pose_order / pose_reached SocketIO pattern. Mirrors firmware_odometry_calibration's
+adapter but deals with OTOS scalars and skips the encoder telemetry (OTOS
+does not expose useful ticks; the ground truth is the operator's physical
+measurement).
+"""
+
+from __future__ import annotations
+import asyncio
+
+import socketio
+from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
+
+from cogip.models import OTOSParameters
+from cogip.models.models import Pose
+from cogip.tools.firmware_parameter_manager.firmware_parameter_manager import FirmwareParameterManager
+from cogip.utils.console_ui import ConsoleUI
+from . import logger
+
+
+class FirmwareAdapter:
+    """Wraps parameter read/write and motion execution for OTOS calibration."""
+
+    PARAM_LINEAR_SCALAR = "otos_linear_scalar"
+    PARAM_ANGULAR_SCALAR = "otos_angular_scalar"
+
+    def __init__(
+        self,
+        sio: socketio.AsyncClient,
+        param_manager: FirmwareParameterManager,
+        pose_reached_event: asyncio.Event,
+        console: ConsoleUI | None = None,
+    ) -> None:
+        self.sio = sio
+        self._param_manager = param_manager
+        self.pose_reached_event = pose_reached_event
+        self._console = console or ConsoleUI()
+
+    # === Parameters ===
+
+    async def load_parameters(self) -> OTOSParameters:
+        """Read the current OTOS scalars from firmware."""
+        logger.info("Loading OTOS parameters from firmware...")
+        linear, angular = await asyncio.gather(
+            self._param_manager.get_parameter_value(self.PARAM_LINEAR_SCALAR),
+            self._param_manager.get_parameter_value(self.PARAM_ANGULAR_SCALAR),
+        )
+        params = OTOSParameters(linear_scalar=linear, angular_scalar=angular)
+        logger.info(f"Loaded OTOS parameters: {params}")
+        return params
+
+    async def save_parameters(self, params: OTOSParameters) -> None:
+        """Write both OTOS scalars back to the firmware."""
+        logger.info(f"Saving OTOS parameters to firmware: {params}")
+        await asyncio.gather(
+            self._param_manager.set_parameter_value(self.PARAM_LINEAR_SCALAR, params.linear_scalar),
+            self._param_manager.set_parameter_value(self.PARAM_ANGULAR_SCALAR, params.angular_scalar),
+        )
+        logger.info("OTOS parameters saved successfully")
+
+    async def save_linear_scalar(self, scalar: float) -> None:
+        await self._param_manager.set_parameter_value(self.PARAM_LINEAR_SCALAR, scalar)
+
+    async def save_angular_scalar(self, scalar: float) -> None:
+        await self._param_manager.set_parameter_value(self.PARAM_ANGULAR_SCALAR, scalar)
+
+    # === Motion Control ===
+
+    async def set_start_position(self, x: float, y: float, orientation: float) -> None:
+        """Reset the OTOS-reported pose to the given reference."""
+        pose = Pose(x=x, y=y, O=orientation)
+        logger.debug(f"Setting start position: {pose}")
+        await self.sio.emit("pose_start", pose.model_dump(), namespace="/calibration")
+
+    async def _send_pose_order(self, x: float, y: float, orientation: float) -> None:
+        pose = Pose(x=x, y=y, O=orientation)
+        self.pose_reached_event.clear()
+        logger.debug(f"Sending pose order: {pose}")
+        await self.sio.emit("pose_order", pose.model_dump(), namespace="/calibration")
+
+    async def _wait_pose_reached(self, timeout: float = 120.0) -> bool:
+        try:
+            await asyncio.wait_for(self.pose_reached_event.wait(), timeout=timeout)
+            return True
+        except TimeoutError:
+            logger.warning(f"Timeout waiting for pose reached (>{timeout}s)")
+            return False
+
+    async def goto(self, x: float, y: float, orientation: float, timeout: float = 120.0) -> bool:
+        await self._send_pose_order(x, y, orientation)
+        return await self._wait_pose_reached(timeout)
+
+    # === Calibration Movement Sequences ===
+
+    async def execute_straight_line(self, distance_mm: int) -> bool:
+        """Drive straight forward by distance_mm (linear scalar phase)."""
+        logger.info(f"Executing straight line movement ({distance_mm} mm)...")
+
+        await self.set_start_position(0, 0, 0)
+        await asyncio.sleep(0.2)
+
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[cyan]Straight line ({task.fields[distance]} mm)[/]"),
+            TimeElapsedColumn(),
+            console=self._console,
+        ) as progress:
+            progress.add_task("", distance=distance_mm)
+
+            success = await self.goto(distance_mm, 0, 0, timeout=60.0)
+            if not success:
+                self._console.show_error("Straight line movement failed (timeout)")
+                return False
+
+        logger.info("Straight line completed")
+        return True
+
+    async def execute_rotations(self, num_rotations: int) -> bool:
+        """Rotate in place by num_rotations * 360° (angular scalar phase).
+
+        Each full turn is split into four quarter-turn pose orders so the
+        motion controller takes the short angular path instead of flipping
+        through the ±180° wrap.
+        """
+        target_orientation = num_rotations * 360.0
+        logger.info(f"Executing {num_rotations} rotations ({target_orientation}°)...")
+
+        await self.set_start_position(0, 0, 0)
+        await asyncio.sleep(0.2)
+
+        quarter_turns = [90, 180, -90, 0]
+
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[cyan]Rotation {task.fields[rotation]}/{task.fields[total_count]}[/]"),
+            TimeElapsedColumn(),
+            console=self._console,
+        ) as progress:
+            task = progress.add_task("", rotation=1, total_count=num_rotations)
+
+            for rotation_num in range(num_rotations):
+                progress.update(task, rotation=rotation_num + 1)
+                for target_angle in quarter_turns:
+                    success = await self.goto(0, 0, target_angle, timeout=30.0)
+                    if not success:
+                        self._console.show_error(
+                            f"Rotation {rotation_num + 1}/{num_rotations} failed at {target_angle}° (timeout)"
+                        )
+                        return False
+
+            progress.update(task, rotation=num_rotations)
+
+        logger.info("Rotations completed")
+        return True

--- a/cogip/tools/firmware_otos_calibration/otos_calibration.py
+++ b/cogip/tools/firmware_otos_calibration/otos_calibration.py
@@ -1,0 +1,218 @@
+"""
+OTOS Calibration Tool.
+
+Calibrates the two OTOS scalars (linear_scalar, angular_scalar) through two
+phases:
+
+    1. Linear scalar - commanded straight line vs. physically measured distance
+    2. Angular scalar - commanded number of rotations vs. physically measured angle
+
+The tool drives the robot through cogip-server, then prompts the operator
+for the physically measured outcome, derives the corrected scalar and
+writes it back to firmware (which re-programs the OTOS chip immediately).
+"""
+
+from __future__ import annotations
+import asyncio
+import sys
+
+import socketio
+
+from cogip.models import FirmwareParametersGroup, OTOSParameters
+from cogip.tools.firmware_parameter_manager.firmware_parameter_manager import FirmwareParameterManager
+from cogip.utils.console_ui import ConsoleUI
+from . import logger
+from .calculator import compute_angular_scalar, compute_linear_scalar
+from .firmware_adapter import FirmwareAdapter
+from .sio_events import SioEvents
+from .types import OtosCalibrationPhaseType
+
+
+class OTOSCalibration:
+    """OTOS calibration controller."""
+
+    def __init__(self, server_url: str, parameters_group: FirmwareParametersGroup):
+        self.server_url = server_url
+        self.console = ConsoleUI()
+
+        self.pose_reached_event = asyncio.Event()
+
+        self.sio = socketio.AsyncClient(logger=False)
+        self.sio_ns = SioEvents(self)
+        self.sio.register_namespace(self.sio_ns)
+
+        self.param_manager = FirmwareParameterManager(self.sio, parameters_group)
+
+        self.firmware = FirmwareAdapter(self.sio, self.param_manager, self.pose_reached_event, self.console)
+
+        self.params: OTOSParameters | None = None
+        self.initial_params: OTOSParameters | None = None
+
+    async def _connect(self) -> None:
+        self.console.show_info(f"Connecting to {self.server_url}...")
+        await self.sio.connect(
+            self.server_url,
+            namespaces=[
+                self.sio_ns.namespace,
+                self.param_manager.namespace,
+            ],
+        )
+        self.console.show_info("Waiting for connections...")
+        while not (self.sio_ns.connected and self.param_manager.is_connected):
+            await asyncio.sleep(0.1)
+        self.console.show_success("Connected to cogip-server")
+
+    async def _disconnect(self) -> None:
+        if self.sio and self.sio.connected:
+            await self.sio.disconnect()
+
+    def _display_intro(self) -> None:
+        self.console.show_panel(
+            "This tool calibrates the OTOS sensor through 2 phases:\n"
+            "1. [header]Linear scalar[/] - drive in a straight line, measure the physical distance\n"
+            "2. [header]Angular scalar[/] - rotate N turns, measure the physical rotation\n\n"
+            "New scalars are written back to firmware immediately and re-programmed on the OTOS chip.",
+            title="OTOS Calibration Tool",
+        )
+
+    def _display_parameters(self, params: OTOSParameters, title: str) -> None:
+        self.console.show_key_value_table(
+            [
+                ("Linear scalar", f"{params.linear_scalar:.6f}"),
+                ("Angular scalar", f"{params.angular_scalar:.6f}"),
+            ],
+            title=title,
+        )
+
+    def _display_scalar_change(self, label: str, before: float, after: float) -> None:
+        table = self.console.create_table(
+            title=f"{label} result",
+            columns=[
+                ("Parameter", {"style": "label"}),
+                ("Before", {"style": "muted", "justify": "right"}),
+                ("After", {"style": "value", "justify": "right"}),
+                ("Change", {"style": "warning", "justify": "right"}),
+            ],
+        )
+        table.add_row(label, f"{before:.6f}", f"{after:.6f}", f"{after - before:+.6f}")
+        self.console.print(table)
+
+    async def _run_linear_phase(self) -> bool:
+        phase = OtosCalibrationPhaseType.LINEAR_SCALAR
+        self.console.show_rule(phase.title)
+        self.console.show_info(phase.description)
+
+        commanded_mm = await self.console.get_integer(phase.command_prompt, default=phase.command_default)
+
+        await self.console.wait_for_enter(
+            "Place the robot at the start mark, aligned forward. Press Enter to start the motion."
+        )
+
+        if not await self.firmware.execute_straight_line(commanded_mm):
+            return False
+
+        measured_mm = await self.console.get_float(phase.measurement_prompt, default=float(commanded_mm))
+
+        try:
+            new_scalar, clamped = compute_linear_scalar(self.params.linear_scalar, float(commanded_mm), measured_mm)
+        except ValueError as exc:
+            self.console.show_error(str(exc))
+            return False
+
+        if clamped:
+            self.console.show_warning("Result was clamped to the OTOS allowed range. Check mechanical setup.")
+
+        self._display_scalar_change("linear_scalar", self.params.linear_scalar, new_scalar)
+
+        if not await self.console.confirm("Accept this result?"):
+            return False
+
+        await self.firmware.save_linear_scalar(new_scalar)
+        self.params.linear_scalar = new_scalar
+        self.console.show_success("linear_scalar written to firmware")
+        return True
+
+    async def _run_angular_phase(self) -> bool:
+        phase = OtosCalibrationPhaseType.ANGULAR_SCALAR
+        self.console.show_rule(phase.title)
+        self.console.show_info(phase.description)
+
+        num_rotations = await self.console.get_integer(phase.command_prompt, default=phase.command_default)
+        commanded_deg = float(num_rotations) * 360.0
+
+        await self.console.wait_for_enter(
+            "Place a rotation marker (e.g. tape on the chassis aligned with a floor mark). "
+            "Press Enter to start the rotation."
+        )
+
+        if not await self.firmware.execute_rotations(num_rotations):
+            return False
+
+        self.console.show_info(f"Commanded rotation: {commanded_deg:.1f}°")
+        measured_deg = await self.console.get_float(phase.measurement_prompt, default=commanded_deg)
+
+        try:
+            new_scalar, clamped = compute_angular_scalar(self.params.angular_scalar, commanded_deg, measured_deg)
+        except ValueError as exc:
+            self.console.show_error(str(exc))
+            return False
+
+        if clamped:
+            self.console.show_warning("Result was clamped to the OTOS allowed range. Check mechanical setup.")
+
+        self._display_scalar_change("angular_scalar", self.params.angular_scalar, new_scalar)
+
+        if not await self.console.confirm("Accept this result?"):
+            return False
+
+        await self.firmware.save_angular_scalar(new_scalar)
+        self.params.angular_scalar = new_scalar
+        self.console.show_success("angular_scalar written to firmware")
+        return True
+
+    async def _run_calibration(self) -> None:
+        self._display_intro()
+
+        self.console.show_info("Loading OTOS parameters from firmware...")
+        self.params = await self.firmware.load_parameters()
+        self.initial_params = self.params.model_copy()
+        self.console.show_success("Parameters loaded successfully")
+        self._display_parameters(self.params, "Initial Parameters")
+
+        while not await self._run_linear_phase():
+            if not await self.console.confirm("Retry linear phase?", default=True):
+                break
+
+        while not await self._run_angular_phase():
+            if not await self.console.confirm("Retry angular phase?", default=True):
+                break
+
+        self.console.print()
+        self._display_parameters(self.params, "Final Calibrated Parameters")
+
+        if not await self.console.confirm("Keep calibrated parameters in firmware?", default=True):
+            self.console.show_warning("Restoring initial parameters...")
+            await self.firmware.save_parameters(self.initial_params)
+            self.console.show_warning("Initial parameters restored.")
+
+    async def run(self) -> None:
+        try:
+            await self._connect()
+            await self._run_calibration()
+        except KeyboardInterrupt:
+            self.console.show_warning("\nCalibration interrupted by user")
+            if self.initial_params and self.firmware:
+                self.console.show_warning("Restoring initial parameters...")
+                await self.firmware.save_parameters(self.initial_params)
+            sys.exit(0)
+        except Exception as exc:
+            self.console.show_error(str(exc))
+            logger.error("Unexpected error during OTOS calibration")
+            if self.initial_params and self.firmware:
+                try:
+                    await self.firmware.save_parameters(self.initial_params)
+                except Exception:
+                    pass
+            sys.exit(1)
+        finally:
+            await self._disconnect()

--- a/cogip/tools/firmware_otos_calibration/otos_parameters.yaml
+++ b/cogip/tools/firmware_otos_calibration/otos_parameters.yaml
@@ -1,0 +1,17 @@
+# OTOS Calibration Parameter Definitions
+#
+# Defines the parameters the OTOS calibration tool reads and writes through
+# the firmware parameter manager. The 'content' values are only fallback
+# defaults used by the schema validator; real values come from the firmware
+# at runtime via load_parameters().
+
+parameters:
+  - name: otos_linear_scalar
+    value:
+      type: float
+      content: 1.0
+
+  - name: otos_angular_scalar
+    value:
+      type: float
+      content: 1.0

--- a/cogip/tools/firmware_otos_calibration/sio_events.py
+++ b/cogip/tools/firmware_otos_calibration/sio_events.py
@@ -1,0 +1,51 @@
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+import polling2
+import socketio
+
+from . import logger
+
+if TYPE_CHECKING:
+    from .otos_calibration import OTOSCalibration
+
+
+class SioEvents(socketio.AsyncClientNamespace):
+    """
+    Handle all SocketIO events received by the OTOS calibration tool on the
+    /calibration namespace. Mirrors the odometry calibration SioEvents: we
+    only need the pose_reached signal to know the robot has finished the
+    requested motion.
+    """
+
+    def __init__(self, calibration: "OTOSCalibration"):
+        super().__init__("/calibration")
+        self.calibration = calibration
+        self.connected = False
+
+    async def on_connect(self) -> None:
+        await asyncio.to_thread(
+            polling2.poll,
+            lambda: self.client.connected is True,
+            step=0.2,
+            poll_forever=True,
+        )
+        logger.info("Connected to cogip-server on /calibration")
+        await self.emit("connected")
+        self.connected = True
+
+    async def on_disconnect(self) -> None:
+        logger.info("Disconnected from cogip-server")
+        self.connected = False
+
+    async def on_connect_error(self, data: dict[str, Any]) -> None:
+        if isinstance(data, dict) and "message" in data:
+            message = data["message"]
+        else:
+            message = data
+        logger.error(f"Connection to cogip-server failed: {message}")
+
+    async def on_pose_reached(self) -> None:
+        """Signal that the robot has reached its target position."""
+        logger.debug("Pose reached")
+        self.calibration.pose_reached_event.set()

--- a/cogip/tools/firmware_otos_calibration/types.py
+++ b/cogip/tools/firmware_otos_calibration/types.py
@@ -1,0 +1,63 @@
+"""
+OTOS Calibration Types
+
+Enum and metadata for the two OTOS calibration phases.
+"""
+
+from enum import IntEnum, auto
+
+
+class OtosCalibrationPhaseType(IntEnum):
+    """Calibration phases for the OTOS sensor."""
+
+    LINEAR_SCALAR = auto()
+    ANGULAR_SCALAR = auto()
+
+    @property
+    def title(self) -> str:
+        titles = {
+            OtosCalibrationPhaseType.LINEAR_SCALAR: "LINEAR SCALAR CALIBRATION",
+            OtosCalibrationPhaseType.ANGULAR_SCALAR: "ANGULAR SCALAR CALIBRATION",
+        }
+        return titles[self]
+
+    @property
+    def description(self) -> str:
+        descriptions = {
+            OtosCalibrationPhaseType.LINEAR_SCALAR: (
+                "The robot will drive forward in a straight line. After it stops, measure the "
+                "physically travelled distance with a tape and enter it. The OTOS linear_scalar "
+                "is adjusted so that the commanded distance matches the physical distance."
+            ),
+            OtosCalibrationPhaseType.ANGULAR_SCALAR: (
+                "The robot will rotate in place by a known number of full turns. After it "
+                "stops, measure the physically rotated angle (e.g. using a marker and a "
+                "reference line) and enter it in degrees. The OTOS angular_scalar is adjusted "
+                "so that the commanded rotation matches the physical rotation."
+            ),
+        }
+        return descriptions[self]
+
+    @property
+    def command_prompt(self) -> str:
+        prompts = {
+            OtosCalibrationPhaseType.LINEAR_SCALAR: "Commanded distance (mm)?",
+            OtosCalibrationPhaseType.ANGULAR_SCALAR: "Number of full rotations?",
+        }
+        return prompts[self]
+
+    @property
+    def command_default(self) -> int:
+        defaults = {
+            OtosCalibrationPhaseType.LINEAR_SCALAR: 1000,
+            OtosCalibrationPhaseType.ANGULAR_SCALAR: 5,
+        }
+        return defaults[self]
+
+    @property
+    def measurement_prompt(self) -> str:
+        prompts = {
+            OtosCalibrationPhaseType.LINEAR_SCALAR: "Measured physical distance (mm)?",
+            OtosCalibrationPhaseType.ANGULAR_SCALAR: "Measured physical rotation (degrees)?",
+        }
+        return prompts[self]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ cogip-mcu-logger = "cogip.tools.mcu_logger.__main__:main"
 cogip-firmware-parameter-manager = "cogip.tools.firmware_parameter_manager.__main__:main"
 cogip-firmware-telemetry = "cogip.tools.firmware_telemetry.__main__:main"
 cogip-odometry-calibration = "cogip.tools.firmware_odometry_calibration.__main__:main"
+cogip-otos-calibration = "cogip.tools.firmware_otos_calibration.__main__:main"
 cogip-pid-calibration = "cogip.tools.firmware_pid_calibration.__main__:main"
 
 [tool.uv]


### PR DESCRIPTION
## Summary

New `cogip-otos-calibration` CLI under `cogip/tools/firmware_otos_calibration/` that mirrors the structure of `firmware_odometry_calibration` but drives the two OTOS scalars exposed by the firmware (cogip/mcu-firmware#243).

Two calibration phases driven through the `/calibration` SocketIO namespace:

1. **Linear scalar**: reset OTOS pose to `(0, 0, 0)`, command a straight line of `N mm`, prompt the operator for the physically measured distance, `new = current * measured / commanded`, clamp to `[0.872, 1.127]`, write back.
2. **Angular scalar**: reset to `(0, 0, 0)`, command `N` full in-place turns (four `90°` sub-moves per turn so the control loop takes the short path), prompt for the actually rotated angle, same ratio, write back.

Reuses the existing `FirmwareParameterManager`, `ConsoleUI`, and the `pose_start` / `pose_order` / `pose_reached` motion pattern. No change to server, copilot or planner apart from the `MotionDirection` re-export below.

## Also in this PR

- `models: export MotionDirection from cogip.models` — `copilot/sio_events.py:on_pose_order` was referencing `models.MotionDirection.FORWARD_ONLY` without importing it directly, so every pose_order sent on SocketIO crashed silently with `AttributeError` (systemd `StandardOutput=null` on the robot hid the traceback). `test_squares` kept working because it goes through the shared-memory path in `copilot.py`, which uses the C++ import directly. Re-exporting the enum fixes the SocketIO pose_order flow without touching copilot.
- `tools: firmware_otos_calibration: shorten straight-line timeout to 10s` — 60 s masked silent stalls; a 1000 mm straight-line completes in ~3 s.

## Depends on

- cogip/mcu-firmware#243 — exposes `otos_linear_scalar` / `otos_angular_scalar` as live `Parameter<float>` and reapplies them to the chip on change via the `has_changed` / `clear_changed` polling API.

## Closes

Closes #202.