### PR TITLE
tools: firmware_pid_calibration: fix PID param names (tracker_ prefix)

### DIFF
--- a/cogip/tools/firmware_pid_calibration/types.py
+++ b/cogip/tools/firmware_pid_calibration/types.py
@@ -57,7 +57,7 @@ class PidType(Enum):
     LINEAR_POSE = dict(
         label="Linear Pose",
         description="Position control (distance)",
-        param_names=("linear_pose_pid_kp", "linear_pose_pid_ki", "linear_pose_pid_kd"),
+        param_names=("tracker_linear_pose_pid_kp", "tracker_linear_pose_pid_ki", "tracker_linear_pose_pid_kd"),
         controller=PB_ControllerEnum.QUADPID_TRACKER,
         command_kind=CommandKind.POSE,
         motion_kind=MotionKind.LINEAR,
@@ -66,7 +66,7 @@ class PidType(Enum):
     ANGULAR_POSE = dict(
         label="Angular Pose",
         description="Position control (rotation)",
-        param_names=("angular_pose_pid_kp", "angular_pose_pid_ki", "angular_pose_pid_kd"),
+        param_names=("tracker_angular_pose_pid_kp", "tracker_angular_pose_pid_ki", "tracker_angular_pose_pid_kd"),
         controller=PB_ControllerEnum.QUADPID_TRACKER,
         command_kind=CommandKind.POSE,
         motion_kind=MotionKind.ANGULAR,
@@ -75,7 +75,7 @@ class PidType(Enum):
     LINEAR_SPEED = dict(
         label="Linear Speed",
         description="Velocity control (linear)",
-        param_names=("linear_speed_pid_kp", "linear_speed_pid_ki", "linear_speed_pid_kd"),
+        param_names=("tracker_linear_speed_pid_kp", "tracker_linear_speed_pid_ki", "tracker_linear_speed_pid_kd"),
         controller=PB_ControllerEnum.TRACKER_SPEED_TUNING,
         command_kind=CommandKind.SPEED,
         motion_kind=MotionKind.LINEAR,
@@ -85,7 +85,7 @@ class PidType(Enum):
     ANGULAR_SPEED = dict(
         label="Angular Speed",
         description="Velocity control (angular)",
-        param_names=("angular_speed_pid_kp", "angular_speed_pid_ki", "angular_speed_pid_kd"),
+        param_names=("tracker_angular_speed_pid_kp", "tracker_angular_speed_pid_ki", "tracker_angular_speed_pid_kd"),
         controller=PB_ControllerEnum.TRACKER_SPEED_TUNING,
         command_kind=CommandKind.SPEED,
         motion_kind=MotionKind.ANGULAR,


### PR DESCRIPTION
## Summary

`cogip-pid-calibration` fails on startup with:
```
✗ "Firmware parameter 'angular_speed_pid_kp' not found"
```
because `PidType.param_names` in `types.py` uses the short form (`linear_pose_pid_kp`, ...) but the bundled YAML schema (`pid_parameters.yaml`) declares them with the `tracker_` prefix. The manager looks the name up in the YAML group and never finds it, before even reaching the firmware.

Align `param_names` on the `tracker_*` form, matching both the YAML and the companion firmware rename.

## Depends on

- cogip/mcu-firmware#244 — renames the twelve PID CAN keys (`linear_pose_pid_kp` → `tracker_linear_pose_pid_kp`, ...). The firmware PR explains why the wire-level key should reflect which chain (tracker vs. future quadpid) owns the value.

Both sides must land together for the tool to succeed against a flashed firmware.

## Test plan

- [ ] With both changes flashed/deployed, `cogip-pid-calibration --server-url http://<robot>:809<ID>` selects each of the four PID types and successfully loads/saves gains.
- [ ] `firmware_odometry_calibration` and `firmware_otos_calibration` still work, confirming the fix is strictly additive on the tool side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)