### PR TITLE
211 - Camera: add focus command for objective lens adjustment

### DIFF
--- a/cogip/tools/camera/__main__.py
+++ b/cogip/tools/camera/__main__.py
@@ -10,6 +10,7 @@ from .calibrate import cmd_calibrate
 from .capture import cmd_capture
 from .charuco import cmd_charuco
 from .detect import cmd_detect
+from .focus import cmd_focus
 from .info import cmd_info
 
 if os.getenv("QT_QPA_PLATFORM") is None:
@@ -21,6 +22,7 @@ app.command(name="charuco")(cmd_charuco)
 app.command(name="capture")(cmd_capture)
 app.command(name="calibrate")(cmd_calibrate)
 app.command(name="detect")(cmd_detect)
+app.command(name="focus")(cmd_focus)
 
 
 @app.callback()

--- a/cogip/tools/camera/focus.py
+++ b/cogip/tools/camera/focus.py
@@ -1,0 +1,132 @@
+import sys
+from typing import Annotated
+
+import cv2
+import typer
+
+from . import logger
+from .arguments import CameraName, VideoCodec
+from .camera import RPiCamera, USBCamera
+
+
+def cmd_focus(
+    id: Annotated[
+        int,
+        typer.Option(
+            "-i",
+            "--id",
+            min=0,
+            help="Robot ID.",
+            envvar=["ROBOT_ID", "CAMERA_ID"],
+        ),
+    ] = 1,
+    camera_name: Annotated[
+        CameraName,
+        typer.Option(
+            help="Name of the camera",
+            envvar="CAMERA_NAME",
+        ),
+    ] = CameraName.rpicam.name,
+    camera_codec: Annotated[
+        VideoCodec,
+        typer.Option(
+            help="Camera video codec",
+            envvar="CAMERA_CODEC",
+        ),
+    ] = VideoCodec.yuyv.name,
+    camera_width: Annotated[
+        int,
+        typer.Option(
+            help="Camera frame width",
+            envvar="CAMERA_WIDTH",
+        ),
+    ] = 728,
+    camera_height: Annotated[
+        int,
+        typer.Option(
+            help="Camera frame height",
+            envvar="CAMERA_HEIGHT",
+        ),
+    ] = 544,
+    zoom: Annotated[
+        float,
+        typer.Option(
+            help="Digital zoom factor to apply to the center of the image",
+            envvar="CAMERA_FOCUS_ZOOM",
+        ),
+    ] = 2.0,
+    no_gui: Annotated[
+        bool,
+        typer.Option(
+            "--no-gui",
+            help="Run without displaying the video window (useful for SSH)",
+        ),
+    ] = False,
+):
+    """Help adjust the camera focus by calculating a sharpness score (Laplacian variance)."""
+    if zoom < 1.0:
+        logger.error("Zoom factor must be >= 1.0")
+        return
+
+    if camera_name == CameraName.rpicam:
+        CameraClass = RPiCamera
+    else:
+        CameraClass = USBCamera
+
+    camera = CameraClass(id, camera_name, camera_codec, camera_width, camera_height)
+    camera.open()
+
+    preview_window_name = "Focus Adjust - Press Esc to exit"
+    if not no_gui:
+        cv2.namedWindow(preview_window_name, cv2.WINDOW_NORMAL)
+        cv2.setWindowProperty(preview_window_name, cv2.WND_PROP_FULLSCREEN, cv2.WINDOW_FULLSCREEN)
+
+    print("Starting focus loop. Press Ctrl+C (or Esc if GUI) to exit.", flush=True)
+
+    try:
+        while True:
+            frame, stream_frame = camera.read()
+            if stream_frame is None:
+                continue
+
+            h, w = stream_frame.shape[:2]
+
+            # Apply digital zoom to center
+            if zoom > 1.0:
+                crop_w = int(w / zoom)
+                crop_h = int(h / zoom)
+                x1 = (w - crop_w) // 2
+                y1 = (h - crop_h) // 2
+                x2 = x1 + crop_w
+                y2 = y1 + crop_h
+                stream_frame = stream_frame[y1:y2, x1:x2]
+
+                # Optionally resize back to original window size for better visibility
+                stream_frame = cv2.resize(stream_frame, (w, h), interpolation=cv2.INTER_LINEAR)
+
+            # Calculate sharpness score (Variance of Laplacian)
+            gray = cv2.cvtColor(stream_frame, cv2.COLOR_BGR2GRAY) if len(stream_frame.shape) == 3 else stream_frame
+            score = cv2.Laplacian(gray, cv2.CV_64F).var()
+
+            if no_gui:
+                # Print score cleanly on a single line
+                sys.stdout.write(f"\rFocus Score: {score:10.2f}")
+                sys.stdout.flush()
+            else:
+                # Display score on image
+                text = f"Focus Score: {score:.2f}"
+                cv2.putText(stream_frame, text, (20, 50), cv2.FONT_HERSHEY_SIMPLEX, 1.5, (0, 0, 255), 3)
+                cv2.imshow(preview_window_name, stream_frame)
+
+                k = cv2.waitKey(1)
+                # Exit on Esc
+                if k == 27:
+                    break
+    except KeyboardInterrupt:
+        pass
+    finally:
+        if no_gui:
+            print()  # New line after the carriage return loop
+        camera.close()
+        if not no_gui:
+            cv2.destroyAllWindows()


### PR DESCRIPTION
### Description
This PR introduces a new `focus` command to the camera tools to simplify adjusting the camera lens focus, especially when dealing with small local displays or latency-prone SSH connections.

Fixes #211

### Changes made
- Added `cogip/tools/camera/focus.py` containing the `cmd_focus` logic.
- Implemented an objective sharpness score calculation using the Variance of Laplacian (`cv2.Laplacian`).
- Added a `--zoom` parameter (default `2.0`) to digitally crop and enlarge the center of the frame, which helps when using the built-in 5" screen.
- Added a `--no-gui` flag for headless execution. This prints the sharpness score directly to `stdout` in real-time without starting an OpenCV window, bypassing X11 latency entirely for SSH users.
- Registered the new `focus` command in `cogip/tools/camera/__main__.py`.

### How to test
**Locally (with display):**
```bash
# Run with default 2x zoom
cogip-camera focus
# Or run with more zoom
cogip-camera focus --zoom 4.0
```

**Remotely (via SSH without X11):**
```bash
cogip-camera focus --no-gui
```